### PR TITLE
Add parseUrl function for Bitbucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,18 @@
 ```bash
 npm install screwdriver-scm-bitbucket
 ```
+#### parseUrl
+Required parameters:
+
+| Parameter        | Type  |  Description |
+| :-------------   | :---- | :-------------|
+| config             | Object | Configuration Object |
+| config.checkoutUrl | String | Checkout url for a repo to parse |
+| config.token  | String | Access token for scm |
+
+#### Output: Promise
+1. Resolves to an scm uri for the repository. Ex: `bitbucket.org:{1234}:branchName`, where `{1234}` is repository's uuid.
+2. Rejects if not able to parse url
 
 ### parseHook
 Required parameters:
@@ -17,8 +29,8 @@ Required parameters:
 | headers        | Object | Request header |
 | payload        | Object | Request payload |
 
-#### Expected Outcome
-An object with the following fields:
+#### Output: Promise
+1. Resolves to an object with the following fields:
 ```js
 {
     type: 'pr',         // can be 'pr' or 'repo'
@@ -31,6 +43,7 @@ An object with the following fields:
     prRef: 'refs/pull-requests/3/from'
 }
 ```
+2. Rejects if not able to parse webhook payload
 
 ## Testing
 

--- a/index.js
+++ b/index.js
@@ -1,10 +1,78 @@
 'use strict';
 
+const Fusebox = require('circuit-fuses');
 const Scm = require('screwdriver-scm-base');
 const hoek = require('hoek');
 const url = require('url');
+const request = require('request');
+const schema = require('screwdriver-data-schema');
+const API_URL = 'https://api.bitbucket.org/2.0';
+const MATCH_COMPONENT_HOSTNAME = 1;
+const MATCH_COMPONENT_USER = 2;
+const MATCH_COMPONENT_REPO = 3;
+const MATCH_COMPONENT_BRANCH = 4;
+
+/**
+ * Get repo information
+ * @method  getRepoInfo
+ * @param   {String}    checkoutUrl     The url to check out repo
+ * @return  {Object}                    An object with host, repo, branch, and username
+ */
+function getRepoInfo(checkoutUrl) {
+    const regex = schema.config.regex.CHECKOUT_URL;
+    const matched = regex.exec(checkoutUrl);
+
+    return {
+        hostname: matched[MATCH_COMPONENT_HOSTNAME],
+        username: matched[MATCH_COMPONENT_USER],
+        repo: matched[MATCH_COMPONENT_REPO],
+        branch: matched[MATCH_COMPONENT_BRANCH].slice(1)
+    };
+}
 
 class BitbucketScm extends Scm {
+    /**
+     * Constructor for Scm
+     * @method constructor
+     * @param  {Object}    config       Configuration
+     * @return {ScmBase}
+     */
+    constructor(config) {
+        super(config);
+
+        this.breaker = new Fusebox(request);
+    }
+
+    /**
+     * Parse the url for a repo for the specific source control
+     * @method parseUrl
+     * @param  {Object}    config
+     * @param  {String}    config.checkoutUrl       Url to parse
+     * @param  {String}    config.token             The token used to authenticate to the SCM
+     * @return {Promise}
+     */
+    _parseUrl(config) {
+        const repoInfo = getRepoInfo(config.checkoutUrl);
+        const getBranchUrl = `${API_URL}/repositories/${repoInfo.username}/${repoInfo.repo}` +
+            `/refs/branches/${repoInfo.branch}`;
+        const options = {
+            url: getBranchUrl,
+            method: 'GET',
+            login_type: 'oauth2',
+            oauth_access_token: config.token
+        };
+
+        return this.breaker.runCommand(options)
+            .then((response) => {
+                if (response.statusCode !== 200) {
+                    throw new Error(`STATUS CODE ${response.statusCode}: ${response.body}`);
+                }
+
+                return `${repoInfo.hostname}:${repoInfo.username}` +
+                    `/${response.body.uuid}:${repoInfo.branch}`;
+            });
+    }
+
     /**
      * Given a SCM webhook payload & its associated headers, aggregate the
      * necessary data to execute a Screwdriver job with.
@@ -60,6 +128,15 @@ class BitbucketScm extends Scm {
         default:
             throw new Error('Only repository and pullrequest events are supported');
         }
+    }
+
+    /**
+    * Retreive stats for the scm
+    * @method stats
+    * @param  {Response}    Object          Object containing stats for the scm
+    */
+    stats() {
+        return this.breaker.stats();
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "git@github.com:screwdriver-cd/scm-bitbucket.git"
   },
   "homepage": "https://github.com/screwdriver-cd/scm-bitbucket",
-  "bugs": "https://github.com/screwdriver-cd/screwdriver/issues",
+  "bugs": "https://github.com/screwdriver-cd/scm-bitbucket/issues",
   "keywords": [
     "screwdriver",
     "yahoo"
@@ -30,14 +30,19 @@
   ],
   "devDependencies": {
     "chai": "^3.5.0",
+    "circuit-fuses": "^2.0.3",
     "eslint": "^3.2.2",
     "eslint-config-screwdriver": "^2.0.0",
     "eslint-plugin-import": "^1.12.0",
-    "jenkins-mocha": "^2.6.0",
-    "sinon": "^1.17.6"
+    "jenkins-mocha": "^3.0.0",
+    "mockery": "^2.0.0",
+    "sinon": "^1.17.6",
+    "sinon-as-promised": "^4.0.2"
   },
   "dependencies": {
     "hoek": "^4.1.0",
+    "request": "^2.75.0",
+    "screwdriver-data-schema": "^14.0.1",
     "screwdriver-scm-base": "^2.0.0"
   }
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,24 +1,186 @@
 'use strict';
 
 const assert = require('chai').assert;
+const mockery = require('mockery');
 const sinon = require('sinon');
-
 const testPayloadOpen = require('./data/pr.opened.json');
 const testPayloadClose = require('./data/pr.closed.json');
 const testPayloadPush = require('./data/repo.push.json');
 
+require('sinon-as-promised');
 sinon.assert.expose(assert, { prefix: '' });
+
+/**
+ * Stub for circuit-fuses wrapper
+ * @method BreakerMock
+ */
+function BreakerMock() {}
 
 describe('index', () => {
     let BitbucketScm;
     let scm;
+    let requestMock;
+    let breakRunMock;
+
+    before(() => {
+        mockery.enable({
+            useCleanCache: true,
+            warnOnUnregistered: false
+        });
+    });
 
     beforeEach(() => {
+        requestMock = sinon.stub();
+        breakRunMock = {
+            runCommand: sinon.stub(),
+            stats: sinon.stub().returns({
+                requests: {
+                    total: 1,
+                    timeouts: 2,
+                    success: 3,
+                    failure: 4,
+                    concurrent: 5,
+                    averageTime: 6
+                },
+                breaker: {
+                    isClosed: false
+                }
+            })
+        };
+
+        BreakerMock.prototype = breakRunMock;
+        mockery.registerMock('circuit-fuses', BreakerMock);
+        mockery.registerMock('request', requestMock);
+
         /* eslint-disable global-require */
         BitbucketScm = require('../index');
         /* eslint-enable global-require */
 
         scm = new BitbucketScm();
+    });
+
+    afterEach(() => {
+        mockery.deregisterAll();
+        mockery.resetCache();
+    });
+
+    after(() => {
+        mockery.disable();
+    });
+
+    describe('parseUrl', () => {
+        const apiUrl = 'https://api.bitbucket.org/2.0/repositories/batman/test/refs/branches/';
+        const token = 'myAccessToken';
+        let fakeResponse;
+
+        beforeEach(() => {
+            fakeResponse = {
+                statusCode: 200,
+                body: {
+                    repository: {
+                        html: {
+                            href: 'https://bitbucket.org/batman/test'
+                        }
+                    },
+                    type: 'repository',
+                    name: 'test',
+                    full_name: 'batman/test',
+                    uuid: '{de7d7695-1196-46a1-b87d-371b7b2945ab}'
+                }
+            };
+            breakRunMock.runCommand.resolves(fakeResponse);
+        });
+
+        it('resolves to the correct parsed url for ssh', () => {
+            const expected =
+                'bitbucket.org:batman/{de7d7695-1196-46a1-b87d-371b7b2945ab}:master';
+            const expectedOptions = {
+                url: `${apiUrl}master`,
+                method: 'GET',
+                login_type: 'oauth2',
+                oauth_access_token: token
+            };
+
+            return scm.parseUrl({
+                checkoutUrl: 'git@bitbucket.org:batman/test.git#master',
+                token
+            }).then((parsed) => {
+                assert.calledWith(breakRunMock.runCommand, expectedOptions);
+                assert.equal(parsed, expected);
+            });
+        });
+
+        it('resolves to the correct parsed url for https', () => {
+            const expected =
+                'bitbucket.org:batman/{de7d7695-1196-46a1-b87d-371b7b2945ab}:mynewbranch';
+            const expectedOptions = {
+                url: `${apiUrl}mynewbranch`,
+                method: 'GET',
+                login_type: 'oauth2',
+                oauth_access_token: 'myAccessToken'
+            };
+
+            return scm.parseUrl({
+                checkoutUrl: 'https://batman@bitbucket.org/batman/test.git#mynewbranch',
+                token: 'myAccessToken'
+            }).then((parsed) => {
+                assert.calledWith(breakRunMock.runCommand, expectedOptions);
+                assert.equal(parsed, expected);
+            });
+        });
+
+        it('rejects if request fails', () => {
+            const err = new Error('Bitbucket API error');
+            const expectedOptions = {
+                url: `${apiUrl}mynewbranch`,
+                method: 'GET',
+                login_type: 'oauth2',
+                oauth_access_token: 'myAccessToken'
+            };
+
+            breakRunMock.runCommand.rejects(err);
+
+            return scm.parseUrl({
+                checkoutUrl: 'https://batman@bitbucket.org/batman/test.git#mynewbranch',
+                token: 'myAccessToken'
+            })
+            .then(() => assert.fail('Should not get here'))
+            .catch((error) => {
+                assert.calledWith(breakRunMock.runCommand, expectedOptions);
+                assert.deepEqual(error, err);
+            });
+        });
+
+        it('rejects if status code is not 200', () => {
+            const expectedOptions = {
+                url: `${apiUrl}mynewbranch`,
+                method: 'GET',
+                login_type: 'oauth2',
+                oauth_access_token: 'myAccessToken'
+            };
+
+            fakeResponse = {
+                statusCode: 404,
+                body: {
+                    error: {
+                        message: 'Resource not found',
+                        detail: 'There is no API hosted at this URL'
+                    }
+                }
+            };
+
+            breakRunMock.runCommand.resolves(fakeResponse);
+
+            return scm.parseUrl({
+                checkoutUrl: 'https://batman@bitbucket.org/batman/test.git#mynewbranch',
+                token: 'myAccessToken'
+            })
+            .then(() => assert.fail('Should not get here'))
+            .catch((error) => {
+                assert.calledWith(breakRunMock.runCommand, expectedOptions);
+                assert.match(error.message, 'STATUS CODE 404');
+            });
+        });
     });
 
     describe('parseHook', () => {
@@ -88,12 +250,44 @@ describe('index', () => {
                 'X-Event-Key': 'issue:created'
             };
 
-            assert.throws(() => scm.parseHook(repoFork, {}),
-                'Only push event is supported for repository');
-            assert.throws(() => scm.parseHook(prComment, {}),
-                'Only created and fullfilled events are supported for pullrequest');
-            assert.throws(() => scm.parseHook(issueCreated, {}),
-                'Only repository and pullrequest events are supported');
+            scm.parseHook(repoFork, {})
+                .then(() => assert.fail('Should not get here'))
+                .catch((error) => {
+                    assert.deepEqual(error.message,
+                        'Only push event is supported for repository');
+                });
+
+            scm.parseHook(prComment, {})
+                .then(() => assert.fail('Should not get here'))
+                .catch((error) => {
+                    assert.deepEqual(error.message,
+                        'Only created and fullfilled events are supported for pullrequest');
+                });
+
+            scm.parseHook(issueCreated, {})
+                .then(() => assert.fail('Should not get here'))
+                .catch((error) => {
+                    assert.deepEqual(error.message,
+                        'Only repository and pullrequest events are supported');
+                });
+        });
+    });
+
+    describe('stats', () => {
+        it('returns the correct stats', () => {
+            assert.deepEqual(scm.stats(), {
+                requests: {
+                    total: 1,
+                    timeouts: 2,
+                    success: 3,
+                    failure: 4,
+                    concurrent: 5,
+                    averageTime: 6
+                },
+                breaker: {
+                    isClosed: false
+                }
+            });
         });
     });
 });


### PR DESCRIPTION
- Takes care of https and ssh url
- We need to pass these fields to make calls to Bitbucket API:
```
login_type: 'oauth2',
oauth_access_token: config.token
```

Relates to https://github.com/screwdriver-cd/screwdriver/issues/255