### PR TITLE
[3] Pass in oauth object correctly

### DIFF
--- a/index.js
+++ b/index.js
@@ -107,7 +107,7 @@ class BitbucketScm extends Scm {
                 }
 
                 return `${repoInfo.hostname}:${repoInfo.username}` +
-                    `/${response.body.uuid}:${repoInfo.branch}`;
+                    `/${response.body.repository.uuid}:${repoInfo.branch}`;
             });
     }
 
@@ -158,10 +158,10 @@ class BitbucketScm extends Scm {
             parsed.username = hoek.reach(payload, 'pullrequest.author.username');
             parsed.checkoutUrl = `${link.protocol}//${parsed.username}`
                 + `@${link.hostname}${link.pathname}.git`;
-            parsed.branch = hoek.reach(payload, 'pullrequest.source.branch.name');
+            parsed.branch = hoek.reach(payload, 'pullrequest.destination.branch.name');
             parsed.sha = hoek.reach(payload, 'pullrequest.source.commit.hash');
             parsed.prNum = hoek.reach(payload, 'pullrequest.id');
-            parsed.prRef = `refs/pull-request/${parsed.prNum}/from`;
+            parsed.prRef = hoek.reach(payload, 'pullrequest.source.branch.name');
 
             return parsed;
         }
@@ -448,8 +448,8 @@ class BitbucketScm extends Scm {
     _getBellConfiguration() {
         return Promise.resolve({
             provider: 'bitbucket',
-            clientId: this.oauthClientId,
-            clientSecret: this.oauthClientSecret,
+            clientId: this.config.oauthClientId,
+            clientSecret: this.config.oauthClientSecret,
             isSecure: this.config.https,
             forceHttps: this.config.https
         });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -63,6 +63,19 @@ describe('index', () => {
                 assert.equal(err.name, 'ValidationError');
             }
         });
+        it('constructs successfully', () => {
+            const testScm = new BitbucketScm({
+                oauthClientId: 'myclientid',
+                oauthClientSecret: 'myclientsecret'
+            });
+
+            assert.deepEqual(testScm.config, {
+                oauthClientId: 'myclientid',
+                oauthClientSecret: 'myclientsecret',
+                fusebox: {},
+                https: false
+            });
+        });
     });
 
     describe('parseUrl', () => {
@@ -77,12 +90,12 @@ describe('index', () => {
                     repository: {
                         html: {
                             href: 'https://bitbucket.org/batman/test'
-                        }
-                    },
-                    type: 'repository',
-                    name: 'test',
-                    full_name: 'batman/test',
-                    uuid: '{de7d7695-1196-46a1-b87d-371b7b2945ab}'
+                        },
+                        type: 'repository',
+                        name: 'test',
+                        full_name: 'batman/test',
+                        uuid: '{de7d7695-1196-46a1-b87d-371b7b2945ab}'
+                    }
                 }
             };
             expectedOptions = {
@@ -179,10 +192,10 @@ describe('index', () => {
                 action: 'opened',
                 username: 'batman',
                 checkoutUrl: 'https://batman@bitbucket.org/batman/test.git',
-                branch: 'mynewbranch',
+                branch: 'master',
                 sha: '40171b678527',
                 prNum: 3,
-                prRef: 'refs/pull-request/3/from',
+                prRef: 'mynewbranch',
                 hookId: '1e8d4e8e-5fcf-4624-b091-b10bd6ecaf5e'
             };
             const headers = {
@@ -200,10 +213,10 @@ describe('index', () => {
                 action: 'closed',
                 username: 'batman',
                 checkoutUrl: 'https://batman@bitbucket.org/batman/test.git',
-                branch: 'mynewbranch',
+                branch: 'master',
                 sha: '40171b678527',
                 prNum: 3,
-                prRef: 'refs/pull-request/3/from',
+                prRef: 'mynewbranch',
                 hookId: '1e8d4e8e-5fcf-4624-b091-b10bd6ecaf5e'
             };
             const headers = {
@@ -994,17 +1007,17 @@ describe('index', () => {
     });
 
     describe('getBellConfiguration', () => {
-        it('returns a default configuration', () => {
+        it('returns a default configuration', () =>
             scm.getBellConfiguration().then((config) => {
                 assert.deepEqual(config, {
                     clientId: 'myclientid',
-                    clietnSecrets: 'myclientsecret',
+                    clientSecret: 'myclientsecret',
                     forceHttps: false,
                     isSecure: false,
                     provider: 'bitbucket'
                 });
-            });
-        });
+            })
+        );
     });
 
     describe('stats', () => {


### PR DESCRIPTION
Fix a couple bugs:

- Oauth is inside `this.config`
- parseHook for PR branch should return the destination instead of source branch
- parseUrl: uuid is inside `repository`
- prRef is just going to be the source branch since bitbucket.org does not have prRef. 