### PR TITLE
Fix bug: POST returns 201 and set decline PR as closed

### DIFF
--- a/index.js
+++ b/index.js
@@ -146,7 +146,7 @@ class BitbucketScm extends Scm {
         case 'pullrequest': {
             if (actionHeader === 'created') {
                 parsed.action = 'opened';
-            } else if (actionHeader === 'fullfilled') {
+            } else if (actionHeader === 'fullfilled' || actionHeader === 'rejected') {
                 parsed.action = 'closed';
             } else {
                 return Promise.resolve(null);
@@ -431,7 +431,7 @@ class BitbucketScm extends Scm {
 
         return this.breaker.runCommand(options)
             .then((response) => {
-                if (response.statusCode !== 200) {
+                if (response.statusCode !== 201) {
                     throw new Error(
                         `STATUS CODE ${response.statusCode}: ${JSON.stringify(response.body)}`);
                 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -207,7 +207,7 @@ describe('index', () => {
                 .then(result => assert.deepEqual(result, expected));
         });
 
-        it('resolves the correct parsed config for closed PR', () => {
+        it('resolves the correct parsed config for closed PR after merged', () => {
             const expected = {
                 type: 'pr',
                 action: 'closed',
@@ -221,6 +221,27 @@ describe('index', () => {
             };
             const headers = {
                 'x-event-key': 'pullrequest:fullfilled',
+                'x-request-uuid': '1e8d4e8e-5fcf-4624-b091-b10bd6ecaf5e'
+            };
+
+            return scm.parseHook(headers, testPayloadClose)
+                .then(result => assert.deepEqual(result, expected));
+        });
+
+        it('resolves the correct parsed config for closed PR after declined', () => {
+            const expected = {
+                type: 'pr',
+                action: 'closed',
+                username: 'batman',
+                checkoutUrl: 'https://batman@bitbucket.org/batman/test.git',
+                branch: 'master',
+                sha: '40171b678527',
+                prNum: 3,
+                prRef: 'mynewbranch',
+                hookId: '1e8d4e8e-5fcf-4624-b091-b10bd6ecaf5e'
+            };
+            const headers = {
+                'x-event-key': 'pullrequest:rejected',
                 'x-request-uuid': '1e8d4e8e-5fcf-4624-b091-b10bd6ecaf5e'
             };
 
@@ -923,7 +944,7 @@ describe('index', () => {
             };
             apiUrl = `${API_URL_V2}/repositories/batman/{1234}/commit/${config.sha}/statuses/build`;
             fakeResponse = {
-                statusCode: 200
+                statusCode: 201
             };
             expectedOptions = {
                 url: apiUrl,
@@ -960,7 +981,7 @@ describe('index', () => {
             });
         });
 
-        it('rejects if status code is not 200', () => {
+        it('rejects if status code is not 201', () => {
             fakeResponse = {
                 statusCode: 401,
                 body: {


### PR DESCRIPTION
- Bitbucket returns 201 for POST
- Fix bug to check against 201
- Via Bitbucket UI, you can decline a PR which is the same as close a PR 