### PR TITLE
Accept 200 as success for updating commit status

### DIFF
--- a/index.js
+++ b/index.js
@@ -431,7 +431,7 @@ class BitbucketScm extends Scm {
 
         return this.breaker.runCommand(options)
             .then((response) => {
-                if (response.statusCode !== 201) {
+                if (response.statusCode !== 201 && response.statusCode !== 200) {
                     throw new Error(
                         `STATUS CODE ${response.statusCode}: ${JSON.stringify(response.body)}`);
                 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -981,7 +981,7 @@ describe('index', () => {
             });
         });
 
-        it('rejects if status code is not 201', () => {
+        it('rejects if status code is not 201 or 200', () => {
             fakeResponse = {
                 statusCode: 401,
                 body: {


### PR DESCRIPTION
- Bitbucket API returns 201 for updating commit status if it is the first update for the sha
- It returns 200 for updating commit status if it is not the first update for the same sha

<img width="1174" alt="screen shot 2016-10-31 at 4 45 23 pm" src="https://cloud.githubusercontent.com/assets/20427140/19875370/88565b14-9f89-11e6-9fa5-5879800df9ef.png">
