### PR TITLE
Return creator, not author, for pull request event

### DIFF
--- a/index.js
+++ b/index.js
@@ -122,6 +122,7 @@ class BitbucketScm extends Scm {
     _parseHook(headers, payload) {
         const [typeHeader, actionHeader] = headers['x-event-key'].split(':');
         const parsed = {};
+        const repoOwner = hoek.reach(payload, 'repository.owner.username');
 
         parsed.hookId = headers['x-request-uuid'];
 
@@ -136,7 +137,7 @@ class BitbucketScm extends Scm {
             parsed.type = 'repo';
             parsed.action = 'push';
             parsed.username = hoek.reach(payload, 'actor.username');
-            parsed.checkoutUrl = `${link.protocol}//${parsed.username}`
+            parsed.checkoutUrl = `${link.protocol}//${repoOwner}`
                 + `@${link.hostname}${link.pathname}.git`;
             parsed.branch = hoek.reach(changes[0], 'new.name');
             parsed.sha = hoek.reach(changes[0], 'new.target.hash');
@@ -155,8 +156,8 @@ class BitbucketScm extends Scm {
             const link = url.parse(hoek.reach(payload, 'repository.links.html.href'));
 
             parsed.type = 'pr';
-            parsed.username = hoek.reach(payload, 'pullrequest.author.username');
-            parsed.checkoutUrl = `${link.protocol}//${parsed.username}`
+            parsed.username = hoek.reach(payload, 'actor.username');
+            parsed.checkoutUrl = `${link.protocol}//${repoOwner}`
                 + `@${link.hostname}${link.pathname}.git`;
             parsed.branch = hoek.reach(payload, 'pullrequest.destination.branch.name');
             parsed.sha = hoek.reach(payload, 'pullrequest.source.commit.hash');

--- a/test/data/pr.closed.json
+++ b/test/data/pr.closed.json
@@ -125,19 +125,19 @@
     "task_count": 0
   },
   "actor": {
-    "username": "batman",
-    "display_name": "Batman",
+    "username": "robin",
+    "display_name": "Robin",
     "type": "user",
     "uuid": "{2dca4f54-ab3f-400c-a777-c059e1ac0394}",
     "links": {
       "self": {
-        "href": "https://api.bitbucket.org/2.0/users/batman"
+        "href": "https://api.bitbucket.org/2.0/users/robin"
       },
       "html": {
-        "href": "https://bitbucket.org/batman/"
+        "href": "https://bitbucket.org/robin/"
       },
       "avatar": {
-        "href": "https://bitbucket.org/account/batman/avatar/32/"
+        "href": "https://bitbucket.org/account/robin/avatar/32/"
       }
     }
   },

--- a/test/data/pr.opened.json
+++ b/test/data/pr.opened.json
@@ -102,19 +102,19 @@
     "task_count": 0
   },
   "actor": {
-    "username": "batman",
-    "display_name": "Batman",
+    "username": "robin",
+    "display_name": "Robin",
     "type": "user",
     "uuid": "{2dca4f54-ab3f-400c-a777-c059e1ac0394}",
     "links": {
       "self": {
-        "href": "https://api.bitbucket.org/2.0/users/batman"
+        "href": "https://api.bitbucket.org/2.0/users/robin"
       },
       "html": {
-        "href": "https://bitbucket.org/batman/"
+        "href": "https://bitbucket.org/robin/"
       },
       "avatar": {
-        "href": "https://bitbucket.org/account/batman/avatar/32/"
+        "href": "https://bitbucket.org/account/robin/avatar/32/"
       }
     }
   },

--- a/test/data/repo.push.json
+++ b/test/data/repo.push.json
@@ -269,19 +269,19 @@
     "uuid": "{de7d7695-1196-46a1-b87d-371b7b2945ab}"
   },
   "actor": {
-    "username": "batman",
-    "display_name": "Batman",
+    "username": "robin",
+    "display_name": "Robin",
     "type": "user",
     "uuid": "{2dca4f54-ab3f-400c-a777-c059e1ac0394}",
     "links": {
       "self": {
-        "href": "https://api.bitbucket.org/2.0/users/batman"
+        "href": "https://api.bitbucket.org/2.0/users/robin"
       },
       "html": {
-        "href": "https://bitbucket.org/batman/"
+        "href": "https://bitbucket.org/robin/"
       },
       "avatar": {
-        "href": "https://bitbucket.org/account/batman/avatar/32/"
+        "href": "https://bitbucket.org/account/robin/avatar/32/"
       }
     }
   }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -190,7 +190,7 @@ describe('index', () => {
             const expected = {
                 type: 'pr',
                 action: 'opened',
-                username: 'batman',
+                username: 'robin',
                 checkoutUrl: 'https://batman@bitbucket.org/batman/test.git',
                 branch: 'master',
                 sha: '40171b678527',
@@ -211,7 +211,7 @@ describe('index', () => {
             const expected = {
                 type: 'pr',
                 action: 'closed',
-                username: 'batman',
+                username: 'robin',
                 checkoutUrl: 'https://batman@bitbucket.org/batman/test.git',
                 branch: 'master',
                 sha: '40171b678527',
@@ -232,7 +232,7 @@ describe('index', () => {
             const expected = {
                 type: 'pr',
                 action: 'closed',
-                username: 'batman',
+                username: 'robin',
                 checkoutUrl: 'https://batman@bitbucket.org/batman/test.git',
                 branch: 'master',
                 sha: '40171b678527',
@@ -253,7 +253,7 @@ describe('index', () => {
             const expected = {
                 type: 'repo',
                 action: 'push',
-                username: 'batman',
+                username: 'robin',
                 checkoutUrl: 'https://batman@bitbucket.org/batman/test.git',
                 branch: 'stuff',
                 sha: '9ff49b2d1437567cad2b5fed7a0706472131e927',


### PR DESCRIPTION
- Since creating Events will require a `creator`, fixing bug in parseHook method to return creator instead of author for pull_request event
- Updated mock data to make sure new changes are working
- Also caught a bug where `checkoutUrl` should have the repo owner, not author username

Will need this information for creating Events in webhooks in Screwdriver API