### PR TITLE
[4] Checkout command name should be sd-checkout-command

### DIFF
--- a/index.js
+++ b/index.js
@@ -496,7 +496,7 @@ class BitbucketScm extends Scm {
             command.push(`git merge ${config.sha}`);
         }
 
-        return Promise.resolve({ name: 'checkout-code', command: command.join(' && ') });
+        return Promise.resolve({ name: 'sd-checkout-code', command: command.join(' && ') });
     }
 
     /**

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "hoek": "^4.1.0",
     "joi": "^9.2.0",
     "request": "^2.75.0",
-    "screwdriver-data-schema": "^15.3.0",
+    "screwdriver-data-schema": "^15.4.0",
     "screwdriver-scm-base": "^2.4.0"
   }
 }

--- a/test/data/commands.json
+++ b/test/data/commands.json
@@ -1,4 +1,4 @@
 {
-    "name": "checkout-code",
+    "name": "sd-checkout-code",
     "command": "echo Cloning https://bitbucket.org/screwdriver-cd/scm-bitbucket, on branch master && git clone --quiet --progress --branch master https://bitbucket.org/screwdriver-cd/scm-bitbucket && cd scm-bitbucket && echo Reset to SHA 40171b678527 && git reset --hard 40171b678527 && echo Setting user name and user email && git config user.name sd-buildbot && git config user.email dev-null@screwdriver.cd"
 }

--- a/test/data/prCommands.json
+++ b/test/data/prCommands.json
@@ -1,4 +1,4 @@
 {
-    "name": "checkout-code",
+    "name": "sd-checkout-code",
     "command": "echo Cloning https://bitbucket.org/screwdriver-cd/scm-bitbucket, on branch master && git clone --quiet --progress --branch master https://bitbucket.org/screwdriver-cd/scm-bitbucket && cd scm-bitbucket && echo Reset to SHA master && git reset --hard master && echo Setting user name and user email && git config user.name sd-buildbot && git config user.email dev-null@screwdriver.cd && echo Fetching PR and merging with master && git fetch origin prBranch && git merge 40171b678527"
 }


### PR DESCRIPTION
Adding `sd-` as a prefix for the command name to avoid stepping on user configs

Blocked by https://github.com/screwdriver-cd/scm-base/pull/29