### PR TITLE
Git clone to $SD_SOURCE_DIR

### DIFF
--- a/index.js
+++ b/index.js
@@ -480,8 +480,8 @@ class BitbucketScm extends Scm {
 
         // Git clone
         command.push(`echo Cloning ${checkoutUrl}, on branch ${config.branch}`);
-        command.push(`git clone --quiet --progress --branch ${config.branch} ${checkoutUrl}`);
-        command.push(`cd ${config.repo}`);
+        command.push(`git clone --quiet --progress --branch ${config.branch} `
+            + `${checkoutUrl} $SD_SOURCE_DIR`);
         // Reset to Sha
         command.push(`echo Reset to SHA ${checkoutRef}`);
         command.push(`git reset --hard ${checkoutRef}`);

--- a/test/data/commands.json
+++ b/test/data/commands.json
@@ -1,4 +1,4 @@
 {
     "name": "sd-checkout-code",
-    "command": "echo Cloning https://bitbucket.org/screwdriver-cd/scm-bitbucket, on branch master && git clone --quiet --progress --branch master https://bitbucket.org/screwdriver-cd/scm-bitbucket && cd scm-bitbucket && echo Reset to SHA 40171b678527 && git reset --hard 40171b678527 && echo Setting user name and user email && git config user.name sd-buildbot && git config user.email dev-null@screwdriver.cd"
+    "command": "echo Cloning https://bitbucket.org/screwdriver-cd/scm-bitbucket, on branch master && git clone --quiet --progress --branch master https://bitbucket.org/screwdriver-cd/scm-bitbucket $SD_SOURCE_DIR && echo Reset to SHA 40171b678527 && git reset --hard 40171b678527 && echo Setting user name and user email && git config user.name sd-buildbot && git config user.email dev-null@screwdriver.cd"
 }

--- a/test/data/prCommands.json
+++ b/test/data/prCommands.json
@@ -1,4 +1,4 @@
 {
     "name": "sd-checkout-code",
-    "command": "echo Cloning https://bitbucket.org/screwdriver-cd/scm-bitbucket, on branch master && git clone --quiet --progress --branch master https://bitbucket.org/screwdriver-cd/scm-bitbucket && cd scm-bitbucket && echo Reset to SHA master && git reset --hard master && echo Setting user name and user email && git config user.name sd-buildbot && git config user.email dev-null@screwdriver.cd && echo Fetching PR and merging with master && git fetch origin prBranch && git merge 40171b678527"
+    "command": "echo Cloning https://bitbucket.org/screwdriver-cd/scm-bitbucket, on branch master && git clone --quiet --progress --branch master https://bitbucket.org/screwdriver-cd/scm-bitbucket $SD_SOURCE_DIR && echo Reset to SHA master && git reset --hard master && echo Setting user name and user email && git config user.name sd-buildbot && git config user.email dev-null@screwdriver.cd && echo Fetching PR and merging with master && git fetch origin prBranch && git merge 40171b678527"
 }


### PR DESCRIPTION
- Switching to using an absolute path when running `git clone` so the src dir will be consistent in the launcher
- SD_SOURCE_DIR is an environment variable set in the launcher
https://github.com/screwdriver-cd/launcher/blob/master/launch.go#L236

Related to https://github.com/screwdriver-cd/screwdriver/issues/312