### PR TITLE
fix(399): Catching up to new version of `data-schema`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,0 @@
-# CHANGELOG
-
-## 2.3.0
-
-Features:
-  * Implement `_getCheckoutCommand` method defined in [scm-base](https://github.com/screwdriver-cd/scm-base).

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "chai": "^3.5.0",
     "eslint": "^3.2.2",
     "eslint-config-screwdriver": "^2.0.0",
-    "jenkins-mocha": "^3.0.0",
+    "jenkins-mocha": "^4.0.0",
     "mockery": "^2.0.0",
     "sinon": "^1.17.6",
     "sinon-as-promised": "^4.0.2"
@@ -49,7 +49,7 @@
     "hoek": "^4.1.0",
     "joi": "^10.0.5",
     "request": "^2.75.0",
-    "screwdriver-data-schema": "^15.4.0",
-    "screwdriver-scm-base": "^2.4.0"
+    "screwdriver-data-schema": "^16.0.0",
+    "screwdriver-scm-base": "^2.5.1"
   }
 }

--- a/test/.eslintrc.yaml
+++ b/test/.eslintrc.yaml
@@ -1,0 +1,4 @@
+extends: screwdriver
+rules:
+    func-names: off
+    prefer-arrow-callback: off

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -16,7 +16,10 @@ const API_URL_V2 = 'https://api.bitbucket.org/2.0';
 require('sinon-as-promised');
 sinon.assert.expose(assert, { prefix: '' });
 
-describe('index', () => {
+describe('index', function () {
+    // Time not important. Only life important.
+    this.timeout(5000);
+
     let BitbucketScm;
     let scm;
     let requestMock;


### PR DESCRIPTION
This should not affect affect the SCM module as it doesn't depend on any of the id => hash specific changes.

Blocked on: https://github.com/screwdriver-cd/scm-base/pull/35
Epic: https://github.com/screwdriver-cd/screwdriver/issues/399