### PR TITLE
fix: can settings username and email for bitbucket checkout

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ The class has a variety of knobs to tweak when interacting with Bitbucket.org.
 | config        | Object | Configuration Object |
 | config.oauthClientId | String | OAuth Client ID provided by Bitbucket application |
 | config.oauthClientSecret | String | OAuth Client Secret provided by Bitbucket application |
+| config.username (sd-buildbot) | String | Bitbucket username for checkout |
+| config.email (dev-null@screwdriver.cd) | String | Bitbucket user email for checkout |
 | config.https (false) | Boolean | Is the Screwdriver API running over HTTPS |
 | config.fusebox ({}) | Object | [Circuit Breaker configuration][circuitbreaker] |
 ```js

--- a/index.js
+++ b/index.js
@@ -92,6 +92,8 @@ class BitbucketScm extends Scm {
      * @method constructor
      * @param  {String}  options.oauthClientId       OAuth Client ID provided by Bitbucket application
      * @param  {String}  options.oauthClientSecret   OAuth Client Secret provided by Bitbucket application
+     * @param  {String}  [options.username=sd-buildbot]           Bitbucket username for checkout
+     * @param  {String}  [options.email=dev-null@screwdriver.cd]  Bitbucket user email for checkout
      * @param  {Boolean} [options.https=false]       Is the Screwdriver API running over HTTPS
      * @param  {Object}  [options.fusebox={}]        Circuit Breaker configuration
      * @return {BitbucketScm}
@@ -100,6 +102,8 @@ class BitbucketScm extends Scm {
         super();
 
         this.config = joi.attempt(config, joi.object().keys({
+            username: joi.string().optional().default('sd-buildbot'),
+            email: joi.string().optional().default('dev-null@screwdriver.cd'),
             https: joi.boolean().optional().default(false),
             oauthClientId: joi.string().required(),
             oauthClientSecret: joi.string().required(),
@@ -635,8 +639,8 @@ class BitbucketScm extends Scm {
         command.push(`git reset --hard ${checkoutRef}`);
         // Set config
         command.push('echo Setting user name and user email');
-        command.push('git config user.name sd-buildbot');
-        command.push('git config user.email dev-null@screwdriver.cd');
+        command.push(`git config user.name ${this.config.username}`);
+        command.push(`git config user.email ${this.config.email}`);
 
         if (config.prRef) {
             command.push(`echo Fetching PR and merging with ${config.branch}`);

--- a/test/data/customPrCommands.json
+++ b/test/data/customPrCommands.json
@@ -1,0 +1,4 @@
+{
+    "name": "sd-checkout-code",
+    "command": "echo Cloning https://hostName/orgName/repoName, on branch branchName && git clone --quiet --progress --branch branchName https://hostName/orgName/repoName $SD_SOURCE_DIR && echo Reset to SHA branchName && git reset --hard branchName && echo Setting user name and user email && git config user.name abcd && git config user.email dev-null@my.email.com && echo Fetching PR and merging with branchName && git fetch origin prBranch && git merge shaValue"
+}

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -5,6 +5,7 @@ const mockery = require('mockery');
 const sinon = require('sinon');
 const testCommands = require('./data/commands.json');
 const testPrCommands = require('./data/prCommands.json');
+const testCustomPrCommands = require('./data/customPrCommands.json');
 const testPayloadOpen = require('./data/pr.opened.json');
 const testPayloadSync = require('./data/pr.sync.json');
 const testPayloadClose = require('./data/pr.closed.json');
@@ -72,12 +73,16 @@ describe('index', function () {
         it('constructs successfully', () => {
             const testScm = new BitbucketScm({
                 oauthClientId: 'myclientid',
-                oauthClientSecret: 'myclientsecret'
+                oauthClientSecret: 'myclientsecret',
+                username: 'abcd',
+                email: 'dev-null@my.email.com'
             });
 
             assert.deepEqual(testScm.config, {
                 oauthClientId: 'myclientid',
                 oauthClientSecret: 'myclientsecret',
+                username: 'abcd',
+                email: 'dev-null@my.email.com',
                 fusebox: {},
                 https: false
             });
@@ -1101,6 +1106,20 @@ describe('index', function () {
             return scm.getCheckoutCommand(config).then((command) => {
                 assert.deepEqual(command, testPrCommands);
             });
+        });
+
+        it('resolves checkout command with custom username and email', () => {
+            scm = new BitbucketScm({
+                oauthClientId: 'myclientid',
+                oauthClientSecret: 'myclientsecret',
+                username: 'abcd',
+                email: 'dev-null@my.email.com'
+            });
+
+            return scm.getCheckoutCommand(config)
+                .then((command) => {
+                    assert.deepEqual(command, testCustomPrCommands);
+                });
         });
     });
 


### PR DESCRIPTION
I want to use own username and email for checkout from Bitbucket.
like this: https://github.com/screwdriver-cd/scm-github/pull/52