### PR TITLE
fix: Bitbucket api returns repository information under the target object

### DIFF
--- a/index.js
+++ b/index.js
@@ -262,7 +262,7 @@ class BitbucketScm extends Scm {
                 }
 
                 return `${repoInfo.hostname}:${repoInfo.username}` +
-                    `/${response.body.repository.uuid}:${repoInfo.branch}`;
+                    `/${response.body.target.repository.uuid}:${repoInfo.branch}`;
             });
     }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -98,14 +98,16 @@ describe('index', function () {
             fakeResponse = {
                 statusCode: 200,
                 body: {
-                    repository: {
-                        html: {
-                            href: 'https://bitbucket.org/batman/test'
-                        },
-                        type: 'repository',
-                        name: 'test',
-                        full_name: 'batman/test',
-                        uuid: '{de7d7695-1196-46a1-b87d-371b7b2945ab}'
+                    target: {
+                        repository: {
+                            html: {
+                                href: 'https://bitbucket.org/batman/test'
+                            },
+                            type: 'repository',
+                            name: 'test',
+                            full_name: 'batman/test',
+                            uuid: '{de7d7695-1196-46a1-b87d-371b7b2945ab}'
+                        }
                     }
                 }
             };


### PR DESCRIPTION
When testing locally I kept on getting an error "Can't read uuid of undefined" so I looked into the response object from bitbucket

I saw in practice that it's returned in `response.body.target.respository` instead of just `response.body.respository`

I went looking through the [documentation](https://developer.atlassian.com/bitbucket/api/2/reference/resource/repositories/%7Busername%7D/%7Brepo_slug%7D/refs/branches/%7Bname%7D) which states that the default response is an error object..

And I couldn't find any swagger object definitions that document this return type. This fixed it for me, but I'm not sure what the right thing to do is..