### PR TITLE
feat(587): Add lastCommitMessage to parsed hook

### DIFF
--- a/index.js
+++ b/index.js
@@ -296,6 +296,8 @@ class BitbucketScm extends Scm {
                 + `@${link.hostname}${link.pathname}.git`;
             parsed.branch = hoek.reach(changes[0], 'new.name');
             parsed.sha = hoek.reach(changes[0], 'new.target.hash');
+            parsed.lastCommitMessage = hoek.reach(changes[0], 'new.target.message',
+                { default: '' });
 
             return Promise.resolve(parsed);
         }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -314,6 +314,7 @@ describe('index', function () {
                 checkoutUrl: 'https://batman@bitbucket.org/batman/test.git',
                 branch: 'stuff',
                 sha: '9ff49b2d1437567cad2b5fed7a0706472131e927',
+                lastCommitMessage: 'testpayload\n',
                 hookId: '1e8d4e8e-5fcf-4624-b091-b10bd6ecaf5e'
             };
             const headers = {


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
I'd like to implement the skipping builds feature (screwdriver-cd/screwdriver#587)
I've already changed `scm-github` module to do it (screwdriver-cd/scm-github#64)

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
This PR adds lastCommitMessage to the result of `parseHook`.


## References

- issue: screwdriver-cd/screwdriver#587
- webhook spec: https://confluence.atlassian.com/bitbucket/event-payloads-740262817.html#EventPayloads-Push