### PR TITLE
fix: Use new workflow and template

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,20 +1,16 @@
-workflow:
-    - publish
-
 shared:
     image: node:6
 
 jobs:
     main:
+        requires: [~pr, ~commit]
         steps:
             - install: npm install
             - test: npm test
 
     publish:
+        requires: [main]
         template: screwdriver-cd/semantic-release
-        steps:
-            - install: npm install semantic-release
-            - publish: npm run semantic-release
         secrets:
             - GH_TOKEN
             - NPM_TOKEN


### PR DESCRIPTION
Pulling in new workflow and getting rid of duplicate semantic release steps