### PR TITLE
feat(911): Add getChangedFiles method

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-/* eslint no-underscore-dangle: ["error", { "allowAfterThis": true }] */
+/* eslint-disable no-underscore-dangle */
 
 'use strict';
 
@@ -200,7 +200,7 @@ class BitbucketScm extends Scm {
         }
 
         return this.breaker.runCommand(params)
-        .then(checkResponseError);
+            .then(checkResponseError);
     }
 
     /**
@@ -224,14 +224,14 @@ class BitbucketScm extends Scm {
             token: config.token,
             url: config.url
         })
-        .then(hookInfo =>
-            this._createWebhook({
-                hookInfo,
-                repoId: repoInfo.repoId,
-                token: config.token,
-                url: config.url
-            })
-        );
+            .then(hookInfo =>
+                this._createWebhook({
+                    hookInfo,
+                    repoId: repoInfo.repoId,
+                    token: config.token,
+                    url: config.url
+                })
+            );
     }
 
     /**
@@ -376,7 +376,7 @@ class BitbucketScm extends Scm {
             });
     }
 
-   /**
+    /**
     * Decorate a given SCM URI with additional data to better display
     * related information. If a branch suffix is not provided, it will default
     * to the master branch
@@ -489,6 +489,21 @@ class BitbucketScm extends Scm {
 
                 return response.body.target.hash;
             });
+    }
+
+    /**
+     * Bitbucket doesn't have an equivalent endpoint to get the changed files,
+     * so returning null for now
+     * @method getFile
+     * @param  {Object}   config              Configuration
+     * @param  {String}   config.type            Can be 'pr' or 'repo'
+     * @param  {Object}   config.webhookPayload  The webhook payload received from the
+     *                                           SCM service.
+     * @param  {String}   config.token           Service token to authenticate with Github
+     * @return {Promise}                      Resolves to the content of the file
+     */
+    _getChangedFiles() {
+        return Promise.resolve(null);
     }
 
     /**
@@ -621,7 +636,7 @@ class BitbucketScm extends Scm {
             });
     }
 
-   /**
+    /**
     * Return a valid Bell configuration (for OAuth)
     * @method getBellConfiguration
     * @return {Promise}
@@ -643,7 +658,7 @@ class BitbucketScm extends Scm {
         });
     }
 
-   /**
+    /**
     * Checkout the source code from a repository; resolves as an object with checkout commands
     * @method getCheckoutCommand
     * @param  {Object}    config
@@ -769,7 +784,7 @@ class BitbucketScm extends Scm {
         return { [scmContext]: stats };
     }
 
-   /**
+    /**
     * Get an array of scm context (e.g. bitbucket:bitbucket.org)
     * @method getScmContexts
     * @return {Array}
@@ -780,7 +795,7 @@ class BitbucketScm extends Scm {
         return contextName;
     }
 
-   /**
+    /**
     * Determine if a scm module can handle the received webhook
     * @method canHandleWebhook
     * @param {Object}    headers     The request headers associated with the webhook payload

--- a/index.js
+++ b/index.js
@@ -377,15 +377,15 @@ class BitbucketScm extends Scm {
     }
 
     /**
-    * Decorate a given SCM URI with additional data to better display
-    * related information. If a branch suffix is not provided, it will default
-    * to the master branch
-    * @method decorateUrl
-    * @param  {Config}    config         Configuration object
-    * @param  {String}    config.scmUri  The scmUri
-    * @param  {String}    config.token   Service token to authenticate with Bitbucket
-    * @return {Object}                   Resolves to a decoratedUrl with url, name, and branch
-    */
+     * Decorate a given SCM URI with additional data to better display
+     * related information. If a branch suffix is not provided, it will default
+     * to the master branch
+     * @method decorateUrl
+     * @param  {Config}    config         Configuration object
+     * @param  {String}    config.scmUri  The scmUri
+     * @param  {String}    config.token   Service token to authenticate with Bitbucket
+     * @return {Object}                   Resolves to a decoratedUrl with url, name, and branch
+     */
     _decorateUrl(config) {
         const scm = getScmUriParts(config.scmUri);
         const options = {
@@ -637,10 +637,10 @@ class BitbucketScm extends Scm {
     }
 
     /**
-    * Return a valid Bell configuration (for OAuth)
-    * @method getBellConfiguration
-    * @return {Promise}
-    */
+     * Return a valid Bell configuration (for OAuth)
+     * @method getBellConfiguration
+     * @return {Promise}
+     */
     _getBellConfiguration() {
         const scmContexts = this._getScmContexts();
         const scmContext = scmContexts[0];
@@ -659,17 +659,17 @@ class BitbucketScm extends Scm {
     }
 
     /**
-    * Checkout the source code from a repository; resolves as an object with checkout commands
-    * @method getCheckoutCommand
-    * @param  {Object}    config
-    * @param  {String}    config.branch        Pipeline branch
-    * @param  {String}    config.host          Scm host to checkout source code from
-    * @param  {String}    config.org           Scm org name
-    * @param  {String}    config.repo          Scm repo name
-    * @param  {String}    config.sha           Commit sha
-    * @param  {String}    [config.prRef]       PR reference (can be a PR branch or reference)
-    * @return {Promise}
-    */
+     * Checkout the source code from a repository; resolves as an object with checkout commands
+     * @method getCheckoutCommand
+     * @param  {Object}    config
+     * @param  {String}    config.branch        Pipeline branch
+     * @param  {String}    config.host          Scm host to checkout source code from
+     * @param  {String}    config.org           Scm org name
+     * @param  {String}    config.repo          Scm repo name
+     * @param  {String}    config.sha           Commit sha
+     * @param  {String}    [config.prRef]       PR reference (can be a PR branch or reference)
+     * @return {Promise}
+     */
     _getCheckoutCommand(config) {
         const checkoutUrl = `${config.host}/${config.org}/${config.repo}`;
         const sshCheckoutUrl = `git@${config.host}:${config.org}/${config.repo}`;
@@ -710,13 +710,13 @@ class BitbucketScm extends Scm {
     }
 
     /**
-    * Get list of objects (each consists of opened PR name and ref (branch)) of a pipeline
-    * @method getOpenedPRs
-    * @param  {Object}   config              Configuration
-    * @param  {String}   config.scmUri       The scmUri to get opened PRs
-    * @param  {String}   config.token        The token used to authenticate to the SCM
-    * @return {Promise}
-    */
+     * Get list of objects (each consists of opened PR name and ref (branch)) of a pipeline
+     * @method getOpenedPRs
+     * @param  {Object}   config              Configuration
+     * @param  {String}   config.scmUri       The scmUri to get opened PRs
+     * @param  {String}   config.token        The token used to authenticate to the SCM
+     * @return {Promise}
+     */
     _getOpenedPRs(config) {
         const repoId = getScmUriParts(config.scmUri).repoId;
 
@@ -740,14 +740,14 @@ class BitbucketScm extends Scm {
     }
 
     /**
-    * Resolve a pull request object based on the config
-    * @method getPrRef
-    * @param  {Object}   config            Configuration
-    * @param  {String}   config.scmUri     The scmUri to get PR info of
-    * @param  {String}   config.token      The token used to authenticate to the SCM
-    * @param  {Integer}  config.prNum      The PR number used to fetch the PR
-    * @return {Promise}
-    */
+     * Resolve a pull request object based on the config
+     * @method getPrRef
+     * @param  {Object}   config            Configuration
+     * @param  {String}   config.scmUri     The scmUri to get PR info of
+     * @param  {String}   config.token      The token used to authenticate to the SCM
+     * @param  {Integer}  config.prNum      The PR number used to fetch the PR
+     * @return {Promise}
+     */
     _getPrInfo(config) {
         const repoId = getScmUriParts(config.scmUri).repoId;
 
@@ -785,10 +785,10 @@ class BitbucketScm extends Scm {
     }
 
     /**
-    * Get an array of scm context (e.g. bitbucket:bitbucket.org)
-    * @method getScmContexts
-    * @return {Array}
-    */
+     * Get an array of scm context (e.g. bitbucket:bitbucket.org)
+     * @method getScmContexts
+     * @return {Array}
+     */
     _getScmContexts() {
         const contextName = [`bitbucket:${this.hostname}`];
 
@@ -796,12 +796,12 @@ class BitbucketScm extends Scm {
     }
 
     /**
-    * Determine if a scm module can handle the received webhook
-    * @method canHandleWebhook
-    * @param {Object}    headers     The request headers associated with the webhook payload
-    * @param {Object}    payload     The webhook payload received from the SCM service
-    * @return {Promise}
-    * */
+     * Determine if a scm module can handle the received webhook
+     * @method canHandleWebhook
+     * @param {Object}    headers     The request headers associated with the webhook payload
+     * @param {Object}    payload     The webhook payload received from the SCM service
+     * @return {Promise}
+     */
     _canHandleWebhook(headers, payload) {
         return this._parseHook(headers, payload).then((parseResult) => {
             if (parseResult === null) {

--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
   },
   "devDependencies": {
     "chai": "^3.5.0",
-    "eslint": "^3.2.2",
-    "eslint-config-screwdriver": "^2.0.0",
+    "eslint": "^4.6.0",
+    "eslint-config-screwdriver": "^3.0.0",
     "jenkins-mocha": "^4.0.0",
     "mockery": "^2.0.0",
     "sinon": "^1.17.6",
@@ -49,7 +49,7 @@
     "hoek": "^5.0.3",
     "joi": "^13.0.0",
     "request": "^2.75.0",
-    "screwdriver-data-schema": "^18.11.3",
-    "screwdriver-scm-base": "^3.0.0"
+    "screwdriver-data-schema": "^18.13.4",
+    "screwdriver-scm-base": "^4.0.1"
   }
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -228,10 +228,21 @@ describe('index', function () {
                 checkoutUrl: 'git@bitbucket.corp.jp:batman/test.git#master',
                 token
             })
-            .then(() => assert.fail('Should not get here'))
-            .catch((error) => {
-                assert.match(error.message, expectedError.message);
-            });
+                .then(() => assert.fail('Should not get here'))
+                .catch((error) => {
+                    assert.match(error.message, expectedError.message);
+                });
+        });
+    });
+
+    describe('getChangedFiles', () => {
+        it('resolves null', () => {
+            scm.getChangedFiles({
+                type: 'pr',
+                payload: testPayloadOpen,
+                token: 'thisisatoken'
+            })
+                .then(result => assert.isNull(result));
         });
     });
 
@@ -1072,7 +1083,7 @@ describe('index', function () {
                     description: 'Screwdriver/123/main'
                 },
                 auth: {
-                    bearer: 'bearerToken'     // Decoded access token
+                    bearer: 'bearerToken' // Decoded access token
                 }
             };
             requestMock.yieldsAsync(null, fakeResponse);
@@ -1228,36 +1239,36 @@ describe('index', function () {
                 token: oauthToken,
                 url: 'url'
             })
-            .then(() => {
-                assert.calledWith(requestMock, {
-                    json: true,
-                    method: 'GET',
-                    auth: {
-                        bearer: oauthToken
-                    },
-                    url: `${API_URL_V2}/repositories/repoId/hooks?pagelen=30&page=1`
+                .then(() => {
+                    assert.calledWith(requestMock, {
+                        json: true,
+                        method: 'GET',
+                        auth: {
+                            bearer: oauthToken
+                        },
+                        url: `${API_URL_V2}/repositories/repoId/hooks?pagelen=30&page=1`
+                    });
+                    assert.calledWith(requestMock, {
+                        body: {
+                            description: 'Screwdriver-CD build trigger',
+                            url: 'url',
+                            active: true,
+                            events: [
+                                'repo:push',
+                                'pullrequest:created',
+                                'pullrequest:fulfilled',
+                                'pullrequest:rejected',
+                                'pullrequest:updated'
+                            ]
+                        },
+                        json: true,
+                        method: 'POST',
+                        auth: {
+                            bearer: oauthToken
+                        },
+                        url: `${API_URL_V2}/repositories/repoId/hooks`
+                    });
                 });
-                assert.calledWith(requestMock, {
-                    body: {
-                        description: 'Screwdriver-CD build trigger',
-                        url: 'url',
-                        active: true,
-                        events: [
-                            'repo:push',
-                            'pullrequest:created',
-                            'pullrequest:fulfilled',
-                            'pullrequest:rejected',
-                            'pullrequest:updated'
-                        ]
-                    },
-                    json: true,
-                    method: 'POST',
-                    auth: {
-                        bearer: oauthToken
-                    },
-                    url: `${API_URL_V2}/repositories/repoId/hooks`
-                });
-            });
         });
 
         it('updates a pre-existing webhook', () => {
@@ -1577,14 +1588,13 @@ describe('index', function () {
                 scmUri,
                 token: oauthToken
             })
-            .then((response) => {
-                assert.calledWith(requestMock, expectedOptions);
-                assert.deepEqual(response, [{
-                    name: 'PR-1',
-                    ref: 'testbranch'
-                }]);
-            }
-            );
+                .then((response) => {
+                    assert.calledWith(requestMock, expectedOptions);
+                    assert.deepEqual(response, [{
+                        name: 'PR-1',
+                        ref: 'testbranch'
+                    }]);
+                });
         });
     });
 
@@ -1623,15 +1633,14 @@ describe('index', function () {
                 token: oauthToken,
                 prNum
             })
-            .then((response) => {
-                assert.calledWith(requestMock, expectedOptions);
-                assert.deepEqual(response, {
-                    name: 'PR-1',
-                    ref: 'testbranch',
-                    sha: 'hashValue'
+                .then((response) => {
+                    assert.calledWith(requestMock, expectedOptions);
+                    assert.deepEqual(response, {
+                        name: 'PR-1',
+                        ref: 'testbranch',
+                        sha: 'hashValue'
+                    });
                 });
-            }
-            );
         });
     });
 


### PR DESCRIPTION
## Context
Adding the getChangedFiles method to bitbucket but they don't have any ways to actually get the changed files.

## Objective
This PR implements `getChangedFiles` to just resolve null.

## Related links
Original issue: https://github.com/screwdriver-cd/screwdriver/issues/911
Blocked by: https://github.com/screwdriver-cd/data-schema/pull/219