### PR TITLE
refactor(hip): Upgrade to node:8

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ const WEBHOOK_PAGE_SIZE = 30;
  * @param  {Number}         response.statusCode                    HTTP status code of the HTTP request
  * @param  {String}         [response.body.error.message]          Error message from the server
  * @param  {String}         [response.body.error.detail.required]  Error resolution message
- * @return {Promise}                                               Resolves when no error encountered.
+ * @return {Promise}                                               Resolves when no error encountered
  *                                                                 Rejects when status code is non-200
  */
 function checkResponseError(response) {
@@ -798,8 +798,8 @@ class BitbucketScm extends Scm {
     /**
      * Determine if a scm module can handle the received webhook
      * @method canHandleWebhook
-     * @param {Object}    headers     The request headers associated with the webhook payload
-     * @param {Object}    payload     The webhook payload received from the SCM service
+     * @param  {Object}    headers     The request headers associated with the webhook payload
+     * @param  {Object}    payload     The webhook payload received from the SCM service
      * @return {Promise}
      */
     _canHandleWebhook(headers, payload) {

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,5 +1,5 @@
 shared:
-    image: node:6
+    image: node:8
 
 jobs:
     main:

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1709,6 +1709,16 @@ describe('index', function () {
             });
         });
 
+        it('returns false when an error is thrown', () => {
+            // eslint-disable-next-line no-underscore-dangle
+            scm._parseHook = () => Promise.resolve({});
+
+            return scm.canHandleWebhook(headers, testPayloadPush)
+                .then((result) => {
+                    assert.strictEqual(result, false);
+                });
+        });
+
         it('returns a false when checkoutUrl dose not match scmContext.', () => {
             headers['x-event-key'] = 'repo:push';
             testPayloadPush.repository.links.html.href = 'https://github.com/batman/test';


### PR DESCRIPTION
## Context

Node.js 6 is slowly becoming deprecated, with popular packages such as `semantic-release` no longer supporting it.

## Objective

* Change image in `screwdriver.yaml` to `node:8`

#### Additional changes

* Bump up coverage to 100%
* Minor whitespacing and JSDoc changes, for consistency