### PR TITLE
fix(450): Check if repo exists before getting permissions

### DIFF
--- a/index.js
+++ b/index.js
@@ -214,10 +214,10 @@ class BitbucketScm extends Scm {
      * is instead updated.
      * @method _addWebhook
      * @param  {Object}    config
-     * @param  {String}    config.scmUri  The SCM URI to add the webhook to
-     * @param  {String}    config.token   Oauth2 token to authenticate with Bitbucket
-     * @param  {String}    config.url     The URL to use for webhook notifications
-     * @return {Promise}                  Resolves upon success
+     * @param  {String}    config.scmUri    The SCM URI to add the webhook to
+     * @param  {String}    config.token     Oauth2 token to authenticate with Bitbucket
+      @param  {String}    config.webhookUrl The URL to use for the webhook notifications
+     * @return {Promise}                    Resolves upon success
      */
     _addWebhook(config) {
         const repoInfo = getScmUriParts(config.scmUri);
@@ -226,14 +226,14 @@ class BitbucketScm extends Scm {
             page: 1,
             repoId: repoInfo.repoId,
             token: config.token,
-            url: config.url
+            url: config.webhookUrl
         })
             .then(hookInfo =>
                 this._createWebhook({
                     hookInfo,
                     repoId: repoInfo.repoId,
                     token: config.token,
-                    url: config.url
+                    url: config.webhookUrl
                 })
             );
     }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1332,7 +1332,7 @@ describe('index', function () {
         });
     });
 
-    describe('_addWebhook', () => {
+    describe.only('_addWebhook', () => {
         const oauthToken = 'oauthToken';
         const scmUri = 'hostName:repoId:branchName';
 
@@ -1356,7 +1356,7 @@ describe('index', function () {
             /* eslint-enable no-underscore-dangle */
                 scmUri,
                 token: oauthToken,
-                url: 'url'
+                webhookUrl: 'url'
             })
                 .then(() => {
                     assert.calledWith(requestMock, {
@@ -1411,7 +1411,7 @@ describe('index', function () {
             /* eslint-enable no-underscore-dangle */
                 scmUri,
                 token: oauthToken,
-                url: 'url'
+                webhookUrl: 'url'
             }).then(() => {
                 assert.calledWith(requestMock, {
                     json: true,
@@ -1479,7 +1479,7 @@ describe('index', function () {
             /* eslint-enable no-underscore-dangle */
                 scmUri,
                 token: oauthToken,
-                url: 'url'
+                webhookUrl: 'url'
             }).then(() => {
                 assert.calledWith(requestMock, {
                     json: true,
@@ -1538,7 +1538,7 @@ describe('index', function () {
             /* eslint-enable no-underscore-dangle */
                 scmUri,
                 token,
-                url: 'url'
+                webhookUrl: 'url'
             }).then(assert.fail, (err) => {
                 assert.strictEqual(err.message, expectedMessage);
             });
@@ -1558,7 +1558,7 @@ describe('index', function () {
             /* eslint-enable no-underscore-dangle */
                 scmUri,
                 token,
-                url: 'url'
+                webhookUrl: 'url'
             }).then(assert.fail, (err) => {
                 assert.strictEqual(err.message, expectedMessage);
             });
@@ -1593,7 +1593,7 @@ describe('index', function () {
             /* eslint-enable no-underscore-dangle */
                 scmUri,
                 token,
-                url: 'url'
+                webhookUrl: 'url'
             }).then(assert.fail, (err) => {
                 assert.strictEqual(err.message, [
                     'Your credentials lack one or more required privilege scopes.',
@@ -1638,7 +1638,7 @@ describe('index', function () {
             /* eslint-enable no-underscore-dangle */
                 scmUri,
                 token,
-                url: 'url'
+                webhookUrl: 'url'
             }).then(assert.fail, (err) => {
                 assert.strictEqual(err.message, expectedMessage);
             });
@@ -1668,7 +1668,7 @@ describe('index', function () {
             /* eslint-enable no-underscore-dangle */
                 scmUri,
                 token,
-                url: 'url'
+                webhookUrl: 'url'
             }).then(assert.fail, (err) => {
                 assert.strictEqual(err.message, expectedMessage);
             });


### PR DESCRIPTION
## Context
In order to remove pipelines for repositories that do not exist, the `getPermissions` interface needs to first uniformly check if a repository exists, and if not, throw an error with `code: 404`. 

In the case of `scm-bitbucket`, the implementation of this method does not throw a 404 for a missing repository. Instead it checks this [endpoint](https://developer.atlassian.com/bitbucket/api/2/reference/resource/repositories/%7Busername%7D) for permissions on all repositories.

Additionally changing `url` to `webhookUrl` in `_addWebhook` to be in accordance with the [interface](https://github.com/screwdriver-cd/scm-base#addwebhook).
## Objective
In `getPermissions`, first check that the repository exists. If not, throw a 404.

## Reference
https://github.com/screwdriver-cd/screwdriver/issues/450