### PR TITLE
fix(1646): [4] add baseBranch to return value in getPrInfo

### DIFF
--- a/index.js
+++ b/index.js
@@ -830,7 +830,8 @@ class BitbucketScm extends Scm {
                 name: `PR-${pr.id}`,
                 ref: pr.source.branch.name,
                 sha: pr.source.commit.hash,
-                url: pr.links.html.href
+                url: pr.links.html.href,
+                baseBranch: pr.source.branch.name
             };
         });
     }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1909,7 +1909,8 @@ describe('index', function () {
                         name: 'PR-1',
                         ref: 'testbranch',
                         sha: 'hashValue',
-                        url: 'https://api.bitbucket.org/2.0/repositories/repoId/pullrequests/1'
+                        url: 'https://api.bitbucket.org/2.0/repositories/repoId/pullrequests/1',
+                        baseBranch: 'testbranch'
                     });
                 });
         });


### PR DESCRIPTION
**Issue #, if available:** https://github.com/screwdriver-cd/screwdriver/issues/1646
When `pipeline.prSync` is called, it needs base branch info for the PR to get next job for `~pr:<branchName>`.

**Description of changes:**
This PR allow `getPrInfo` to return `baseBranch` value which contains the base branch name of a PR.

This PR is requires below changes before merge.
https://github.com/screwdriver-cd/scm-base/pull/70
https://github.com/screwdriver-cd/data-schema/pull/339

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of your choice and that I have the authority necessary to make this contribution on behalf of its copyright owner.
