### PR TITLE
fix: (#1662) updated decorate author and commit to replace user uuid …

### DIFF
--- a/index.js
+++ b/index.js
@@ -355,7 +355,7 @@ class BitbucketScm extends Scm {
      */
     _decorateAuthor(config) {
         const options = {
-            url: `${USER_URL}/${config.username}`,
+            url: `${USER_URL}/${encodeURIComponent(config.username)}`,
             method: 'GET',
             json: true,
             auth: {
@@ -374,7 +374,7 @@ class BitbucketScm extends Scm {
                 return {
                     url: body.links.html.href,
                     name: body.display_name,
-                    username: body.username,
+                    username: body.uuid,
                     avatar: body.links.avatar.href
                 };
             });
@@ -448,7 +448,7 @@ class BitbucketScm extends Scm {
 
                 // eslint-disable-next-line
                 return this._decorateAuthor({
-                    username: body.author.user.username,
+                    username: body.author.user.uuid,
                     token: config.token
                 }).then(author => ({
                     url: body.links.html.href,

--- a/index.js
+++ b/index.js
@@ -290,7 +290,7 @@ class BitbucketScm extends Scm {
     _parseHook(headers, payload) {
         const [typeHeader, actionHeader] = headers['x-event-key'].split(':');
         const parsed = {};
-        const repoOwner = hoek.reach(payload, 'repository.owner.username');
+        const repoOwner = hoek.reach(payload, 'repository.owner.uuid');
         const scmContexts = this._getScmContexts();
 
         parsed.hookId = headers['x-request-uuid'];
@@ -306,8 +306,8 @@ class BitbucketScm extends Scm {
 
             parsed.type = 'repo';
             parsed.action = 'push';
-            parsed.username = hoek.reach(payload, 'actor.username');
-            parsed.checkoutUrl = `${link.protocol}//${repoOwner}`
+            parsed.username = hoek.reach(payload, 'actor.uuid');
+            parsed.checkoutUrl = `${link.protocol}//${encodeURIComponent(repoOwner)}`
                 + `@${link.hostname}${link.pathname}.git`;
             parsed.branch = hoek.reach(changes[0], 'new.name');
             parsed.sha = hoek.reach(changes[0], 'new.target.hash');
@@ -330,8 +330,8 @@ class BitbucketScm extends Scm {
             const link = url.parse(hoek.reach(payload, 'repository.links.html.href'));
 
             parsed.type = 'pr';
-            parsed.username = hoek.reach(payload, 'actor.username');
-            parsed.checkoutUrl = `${link.protocol}//${repoOwner}`
+            parsed.username = hoek.reach(payload, 'actor.uuid');
+            parsed.checkoutUrl = `${link.protocol}//${encodeURIComponent(repoOwner)}`
                 + `@${link.hostname}${link.pathname}.git`;
             parsed.branch = hoek.reach(payload, 'pullrequest.destination.branch.name');
             parsed.sha = hoek.reach(payload, 'pullrequest.source.commit.hash');

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -386,7 +386,7 @@ describe('index', function () {
     });
 
     describe('decorateAuthor', () => {
-        const apiUrl = `${API_URL_V2}/users/batman`;
+        const apiUrl = `${API_URL_V2}/users/%7B4f1a9b7f-586e-4e80-b9eb-a7589b4a165f%7D`;
         const expectedOptions = {
             url: apiUrl,
             method: 'GET',
@@ -401,12 +401,11 @@ describe('index', function () {
             fakeResponse = {
                 statusCode: 200,
                 body: {
-                    username: 'batman',
                     display_name: 'Batman',
                     uuid: '{4f1a9b7f-586e-4e80-b9eb-a7589b4a165f}',
                     links: {
                         html: {
-                            href: 'https://bitbucket.org/batman/'
+                            href: 'https://bitbucket.org/%7B4f1a9b7f-586e-4e80-b9eb-a7589b4a165f%7D/' // eslint-disable-line max-len
                         },
                         avatar: {
                             href: 'https://bitbucket.org/account/batman/avatar/32/'
@@ -419,14 +418,14 @@ describe('index', function () {
 
         it('resolves to correct decorated author', () => {
             const expected = {
-                url: 'https://bitbucket.org/batman/',
+                url: 'https://bitbucket.org/%7B4f1a9b7f-586e-4e80-b9eb-a7589b4a165f%7D/',
                 name: 'Batman',
-                username: 'batman',
+                username: '{4f1a9b7f-586e-4e80-b9eb-a7589b4a165f}',
                 avatar: 'https://bitbucket.org/account/batman/avatar/32/'
             };
 
             return scm.decorateAuthor({
-                username: 'batman',
+                username: '{4f1a9b7f-586e-4e80-b9eb-a7589b4a165f}',
                 token
             }).then((decorated) => {
                 assert.calledWith(requestMock, expectedOptions);
@@ -448,7 +447,7 @@ describe('index', function () {
             requestMock.yieldsAsync(null, fakeResponse, fakeResponse.body);
 
             return scm.decorateAuthor({
-                username: 'batman',
+                username: '{4f1a9b7f-586e-4e80-b9eb-a7589b4a165f}',
                 token
             }).then(() => {
                 assert.fail('Should not get here');
@@ -464,7 +463,7 @@ describe('index', function () {
             requestMock.yieldsAsync(err);
 
             return scm.decorateAuthor({
-                username: 'batman',
+                username: '{4f1a9b7f-586e-4e80-b9eb-a7589b4a165f}',
                 token
             }).then(() => {
                 assert.fail('Should not get here');
@@ -574,7 +573,7 @@ describe('index', function () {
         const sha = '1111111111111111111111111111111111111111';
         const repoUrl =
             `${API_URL_V2}/repositories/repoId/commit/${sha}`;
-        const authorUrl = `${API_URL_V2}/users/username`;
+        const authorUrl = `${API_URL_V2}/users/%7Buuid%7D`;
         const selfLink = `https://bitbucket.org/repoId/commits/${sha}`;
         const repoOptions = {
             url: repoUrl,
@@ -607,7 +606,7 @@ describe('index', function () {
                     },
                     author: {
                         user: {
-                            username: 'username'
+                            uuid: '{uuid}'
                         }
                     }
                 }
@@ -615,15 +614,14 @@ describe('index', function () {
             fakeAuthorResponse = {
                 statusCode: 200,
                 body: {
-                    username: 'username',
                     display_name: 'displayName',
-                    uuid: 'uuid',
+                    uuid: '{uuid}',
                     links: {
                         html: {
-                            href: 'https://bitbucket.org/username/'
+                            href: 'https://bitbucket.org/%7Buuid%7D/'
                         },
                         avatar: {
-                            href: 'https://bitbucket.org/account/username/avatar/32/'
+                            href: 'https://bitbucket.org/account/%7Buuid%7D/avatar/32/'
                         }
                     }
                 }
@@ -639,10 +637,10 @@ describe('index', function () {
                 url: selfLink,
                 message: 'testing',
                 author: {
-                    url: 'https://bitbucket.org/username/',
+                    url: 'https://bitbucket.org/%7Buuid%7D/',
                     name: 'displayName',
-                    username: 'username',
-                    avatar: 'https://bitbucket.org/account/username/avatar/32/'
+                    username: '{uuid}',
+                    avatar: 'https://bitbucket.org/account/%7Buuid%7D/avatar/32/'
                 }
             };
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -252,8 +252,8 @@ describe('index', function () {
             const expected = {
                 type: 'pr',
                 action: 'opened',
-                username: 'robin',
-                checkoutUrl: 'https://batman@bitbucket.org/batman/test.git',
+                username: '{2dca4f54-ab3f-400c-a777-c059e1ac0394}',
+                checkoutUrl: 'https://%7B2dca4f54-ab3f-400c-a777-c059e1ac0394%7D@bitbucket.org/batman/test.git', // eslint-disable-line max-len
                 branch: 'master',
                 sha: '40171b678527',
                 prNum: 3,
@@ -274,8 +274,8 @@ describe('index', function () {
             const expected = {
                 type: 'pr',
                 action: 'synchronized',
-                username: 'batman',
-                checkoutUrl: 'https://batman@bitbucket.org/batman/test.git',
+                username: '{2dca4f54-ab3f-400c-a777-c059e1ac0394}',
+                checkoutUrl: 'https://%7B2dca4f54-ab3f-400c-a777-c059e1ac0394%7D@bitbucket.org/batman/test.git', // eslint-disable-line max-len
                 branch: 'master',
                 sha: 'caeae8cd5fc9',
                 prNum: 7,
@@ -296,8 +296,8 @@ describe('index', function () {
             const expected = {
                 type: 'pr',
                 action: 'closed',
-                username: 'robin',
-                checkoutUrl: 'https://batman@bitbucket.org/batman/test.git',
+                username: '{2dca4f54-ab3f-400c-a777-c059e1ac0394}',
+                checkoutUrl: 'https://%7B2dca4f54-ab3f-400c-a777-c059e1ac0394%7D@bitbucket.org/batman/test.git', // eslint-disable-line max-len
                 branch: 'master',
                 sha: '40171b678527',
                 prNum: 3,
@@ -318,8 +318,8 @@ describe('index', function () {
             const expected = {
                 type: 'pr',
                 action: 'closed',
-                username: 'robin',
-                checkoutUrl: 'https://batman@bitbucket.org/batman/test.git',
+                username: '{2dca4f54-ab3f-400c-a777-c059e1ac0394}',
+                checkoutUrl: 'https://%7B2dca4f54-ab3f-400c-a777-c059e1ac0394%7D@bitbucket.org/batman/test.git', // eslint-disable-line max-len
                 branch: 'master',
                 sha: '40171b678527',
                 prNum: 3,
@@ -340,8 +340,8 @@ describe('index', function () {
             const expected = {
                 type: 'repo',
                 action: 'push',
-                username: 'robin',
-                checkoutUrl: 'https://batman@bitbucket.org/batman/test.git',
+                username: '{2dca4f54-ab3f-400c-a777-c059e1ac0394}',
+                checkoutUrl: 'https://%7B2dca4f54-ab3f-400c-a777-c059e1ac0394%7D@bitbucket.org/batman/test.git', // eslint-disable-line max-len
                 branch: 'stuff',
                 sha: '9ff49b2d1437567cad2b5fed7a0706472131e927',
                 lastCommitMessage: 'testpayload\n',


### PR DESCRIPTION
…with username


## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
We need to merge the fix for supporting the GDPR changes for Bitbucket API as reported in issue #1662.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
This PR will fix the username usage for decorating the author and commit.  Instead of using the username from Bitbucket, we will use the user's uuid.  Username has been deprecated by Bitbucket for majority of their API and will break Bitbucket support on Screwdriver.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
Please refer to https://github.com/screwdriver-cd/screwdriver/issues/1662

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
