### PR TITLE
Fix getFile value to response.body

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,6 @@ const joi = require('joi');
 const url = require('url');
 const request = require('request');
 const schema = require('screwdriver-data-schema');
-const API_URL_V1 = 'https://api.bitbucket.org/1.0';
 const API_URL_V2 = 'https://api.bitbucket.org/2.0';
 const REPO_URL = `${API_URL_V2}/repositories`;
 const USER_URL = `${API_URL_V2}/users`;
@@ -523,7 +522,7 @@ class BitbucketScm extends Scm {
     _getFile(config) {
         const scm = getScmUriParts(config.scmUri);
         const branch = config.ref || scm.branch;
-        const fileUrl = `${API_URL_V1}/repositories/${scm.repoId}/src/${branch}/${config.path}`;
+        const fileUrl = `${API_URL_V2}/repositories/${scm.repoId}/src/${branch}/${config.path}`;
         const options = {
             url: fileUrl,
             method: 'GET',

--- a/index.js
+++ b/index.js
@@ -539,7 +539,7 @@ class BitbucketScm extends Scm {
                         `STATUS CODE ${response.statusCode}: ${JSON.stringify(response.body)}`);
                 }
 
-                return response.body.data;
+                return response.body;
             });
     }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -835,12 +835,7 @@ describe('index', function () {
         beforeEach(() => {
             fakeResponse = {
                 statusCode: 200,
-                body: {
-                    node: 'nodeValue',
-                    path: 'path/to/file.txt',
-                    data: 'dataValue',
-                    size: 14
-                }
+                body: 'dataValue'
             };
             requestMock.yieldsAsync(null, fakeResponse, fakeResponse.body);
         });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -13,7 +13,6 @@ const testPayloadSync = require('./data/pr.sync.json');
 const testPayloadClose = require('./data/pr.closed.json');
 const testPayloadPush = require('./data/repo.push.json');
 const token = 'myAccessToken';
-const API_URL_V1 = 'https://api.bitbucket.org/1.0';
 const API_URL_V2 = 'https://api.bitbucket.org/2.0';
 
 sinon.assert.expose(assert, { prefix: '' });
@@ -816,7 +815,7 @@ describe('index', function () {
     });
 
     describe('getFile', () => {
-        const apiUrl = `${API_URL_V1}/repositories/repoId/src/branchName/path/to/file.txt`;
+        const apiUrl = `${API_URL_V2}/repositories/repoId/src/branchName/path/to/file.txt`;
         const scmUri = 'hostName:repoId:branchName';
         const params = {
             scmUri,


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
With the update of the getFile to use the Bitbucket API 2.0, the response no longer is a JSON object, it is naw the raw file.  In order to support this, we need to return response.body instead of response.body.data.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
This PR fixes the Bitbucket file download.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
The bug report for this is #1689.

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
