### PR TITLE
fix(2185): Add default branch (hardcode for now) [1.5]

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,7 +70,7 @@ function getRepoInfo(checkoutUrl) {
     return {
         hostname: matched[MATCH_COMPONENT_HOSTNAME],
         repo: matched[MATCH_COMPONENT_REPO],
-        branch: matched[MATCH_COMPONENT_BRANCH].slice(1),
+        branch: matched[MATCH_COMPONENT_BRANCH] ? matched[MATCH_COMPONENT_BRANCH].slice(1) : null,
         username: matched[MATCH_COMPONENT_USER]
     };
 }
@@ -259,8 +259,11 @@ class BitbucketScm extends Scm {
      */
     async _parseUrl(config) {
         const repoInfo = getRepoInfo(config.checkoutUrl);
+        // TODO: add logic to fetch default branch
+        // See https://jira.atlassian.com/browse/BCLOUD-20212
+        const branch = repoInfo.branch || 'master';
         const branchUrl =
-            `${REPO_URL}/${repoInfo.username}/${repoInfo.repo}/refs/branches/${repoInfo.branch}`;
+            `${REPO_URL}/${repoInfo.username}/${repoInfo.repo}/refs/branches/${branch}`;
         const token = await this._getToken();
 
         const options = {
@@ -288,7 +291,7 @@ class BitbucketScm extends Scm {
         }
 
         return `${repoInfo.hostname}:${repoInfo.username}` +
-            `/${response.body.target.repository.uuid}:${repoInfo.branch}`;
+            `/${response.body.target.repository.uuid}:${branch}`;
     }
 
     /**

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "chai": "^4.2.0",
     "eslint": "^4.19.1",
     "eslint-config-screwdriver": "^3.0.1",
-    "jenkins-mocha": "^6.0.0",
+    "jenkins-mocha": "^8.0.0",
     "mockery": "^2.0.0",
     "sinon": "^4.5.0"
   },
@@ -48,7 +48,7 @@
     "hoek": "^5.0.4",
     "joi": "^13.7.0",
     "request": "^2.88.0",
-    "screwdriver-data-schema": "^18.38.0",
+    "screwdriver-data-schema": "^19.12.1",
     "screwdriver-scm-base": "^4.0.5"
   }
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -151,6 +151,28 @@ describe('index', function () {
             });
         });
 
+        it('resolves to the correct parsed url for ssh wtih default branch', () => {
+            const expected =
+                'bitbucket.org:batman/{de7d7695-1196-46a1-b87d-371b7b2945ab}:master';
+
+            expectedOptions = {
+                url: `${apiUrl}/master`,
+                method: 'GET',
+                json: true,
+                auth: {
+                    bearer: systemToken
+                }
+            };
+
+            return scm.parseUrl({
+                checkoutUrl: 'git@bitbucket.org:batman/test.git',
+                token
+            }).then((parsed) => {
+                assert.calledWith(requestMock, expectedOptions);
+                assert.equal(parsed, expected);
+            });
+        });
+
         it('resolves to the correct parsed url for https', () => {
             const expected =
                 'bitbucket.org:batman/{de7d7695-1196-46a1-b87d-371b7b2945ab}:mynewbranch';


### PR DESCRIPTION
## Context

Since we are removing setting default branch in API/UI, we will need to set it in the plugin.

## Objective

This PR sets the default branch to `master` while we wait for bitbucket add a default branch field.

## References

Bitbucket issue: https://jira.atlassian.com/browse/BCLOUD-20212
Related to https://github.com/screwdriver-cd/screwdriver/issues/2185

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
