### PR TITLE
feat: upgrade hapiv19 dependencies. BREAKING CHANGE: scm-base version

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@
 
 const Fusebox = require('circuit-fuses').breaker;
 const Scm = require('screwdriver-scm-base');
-const hoek = require('hoek');
+const hoek = require('@hapi/hoek');
 const joi = require('joi');
 const url = require('url');
 const request = require('request');

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "screwdriver-scm-bitbucket",
-  "version": "2.3.0",
+  "version": "4.0.0",
   "description": "This scm plugin extends the [scm-base-class](https://github.com/screwdriver-cd/scm-base), and provides methods to fetch and update data in Bitbucket.",
   "main": "index.js",
   "scripts": {
     "pretest": "eslint .",
-    "test": "jenkins-mocha --recursive",
+    "test": "mocha --recursive",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
   "repository": {
@@ -39,16 +39,16 @@
     "chai": "^4.2.0",
     "eslint": "^4.19.1",
     "eslint-config-screwdriver": "^3.0.1",
-    "jenkins-mocha": "^6.0.0",
+    "mocha": "^8.1.2",
     "mockery": "^2.0.0",
     "sinon": "^4.5.0"
   },
   "dependencies": {
+    "@hapi/hoek": "^9.0.4",
     "circuit-fuses": "^4.0.4",
-    "hoek": "^5.0.4",
-    "joi": "^13.7.0",
+    "joi": "^17.2.1",
     "request": "^2.88.0",
-    "screwdriver-data-schema": "^18.38.0",
-    "screwdriver-scm-base": "^4.0.5"
+    "screwdriver-data-schema": "^20.0.0",
+    "screwdriver-scm-base": "^7.0.0"
   }
 }

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,5 +1,5 @@
 shared:
-    image: node:8
+    image: node:12
 
 jobs:
     main:


### PR DESCRIPTION
## Context

Screwdriver hapi.js dependencies are outdated and not supported anymore.

## Objective

This PR majorly upgrades @hapi/joi version and fixes all schema related changes to be compatible with latest @hapi js dependencies.

## References

https://github.com/screwdriver-cd/screwdriver/issues/1958

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
