### PR TITLE
fix:[2] Unify error objects with GitHub errors.

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,13 +47,13 @@ function checkResponseError(response) {
     const errorMessage = hoek.reach(response, 'body.error.message', {
         default: `SCM service unavailable (${response.statusCode}).`
     });
-    const errorReason = hoek.reach(response, 'body.error.detail.required', {
+    const errorReason = hoek.reach(response, 'body.error.detail', {
         default: JSON.stringify(response.body)
     });
 
     const error = new Error(`${errorMessage} Reason "${errorReason}"`);
 
-    error.code = response.statusCode;
+    error.status = response.statusCode;
     throw error;
 }
 
@@ -527,10 +527,8 @@ class BitbucketScm extends Scm {
 
         const response = await this.breaker.runCommand(options);
 
-        if (response.statusCode !== 200) {
-            throw new Error(
-                `STATUS CODE ${response.statusCode}: ${JSON.stringify(response.body)}`);
-        }
+        checkResponseError(response);
+        // `STATUS CODE ${response.statusCode}: ${JSON.stringify(response.body)}`);
 
         return response.body.target.hash;
     }

--- a/index.js
+++ b/index.js
@@ -528,7 +528,6 @@ class BitbucketScm extends Scm {
         const response = await this.breaker.runCommand(options);
 
         checkResponseError(response);
-        // `STATUS CODE ${response.statusCode}: ${JSON.stringify(response.body)}`);
 
         return response.body.target.hash;
     }

--- a/package.json
+++ b/package.json
@@ -42,8 +42,8 @@
     "mocha": "^8.2.1",
     "mocha-multi-reporters": "^1.5.1",
     "mocha-sonarqube-reporter": "^1.0.2",
-    "nyc": "^15.0.0",
     "mockery": "^2.0.0",
+    "nyc": "^15.0.0",
     "sinon": "^4.5.0"
   },
   "dependencies": {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -857,7 +857,9 @@ describe('index', function () {
                 assert.fail('Should not get here');
             }).catch((error) => {
                 assert.calledWith(requestMock, expectedOptions);
-                assert.match(error.message, 'STATUS CODE 404');
+                assert.match(error.message, 'Resource not found Reason ' +
+                    '"There is no API hosted at this URL"');
+                assert.match(error.status, 404);
             });
         });
 
@@ -1744,10 +1746,7 @@ describe('index', function () {
                 type: 'error',
                 error: {
                     message: 'Your credentials lack one or more required privilege scopes.',
-                    detail: {
-                        granted: ['repository'],
-                        required: ['webhook']
-                    }
+                    detail: 'webhook'
                 }
             };
 
@@ -1771,6 +1770,7 @@ describe('index', function () {
                 ]
             }).then(assert.fail, (err) => {
                 assert.strictEqual(err.message, expectedMessage);
+                assert.strictEqual(err.status, 403);
             });
         });
 
@@ -1806,10 +1806,7 @@ describe('index', function () {
                 type: 'error',
                 error: {
                     message: 'Your credentials lack one or more required privilege scopes.',
-                    detail: {
-                        granted: ['repository'],
-                        required: ['webhook']
-                    }
+                    detail: 'webhook'
                 }
             };
 
@@ -1855,10 +1852,7 @@ describe('index', function () {
                 type: 'error',
                 error: {
                     message: 'Your credentials lack one or more required privilege scopes.',
-                    detail: {
-                        granted: ['repository'],
-                        required: ['webhook']
-                    }
+                    detail: 'webhook'
                 }
             };
 


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Scms are using different error objects and API does not handle GitLab error objects.
e.g. https://github.com/screwdriver-cd/screwdriver/blob/master/plugins/webhooks/index.js#L405

These errors should be handled by API.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
- Error object has status property instead of code property.
- Error message use body.error.detail instead of body.error.detail.required

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
- https://github.com/screwdriver-cd/screwdriver/issues/2367
- https://github.com/screwdriver-cd/scm-gitlab/pull/36/
- [Bitbucket error response example](https://developer.atlassian.com/bitbucket/api/2/reference/resource/repositories/%7Bworkspace%7D/%7Brepo_slug%7D/hooks)

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
