### PR TITLE
fix(1961): Response does not need to be JSON parsed

### DIFF
--- a/index.js
+++ b/index.js
@@ -1037,9 +1037,7 @@ class BitbucketScm extends Scm {
         }
 
         const response = await this.breaker.runCommand(params);
-
-        // we will have to parse the body since we are sending a normal FORM POST request
-        const body = JSON.parse(response.body);
+        const { body } = response;
 
         if (response.statusCode !== 200) {
             throw new Error(`STATUS CODE ${response.statusCode}: ${JSON.stringify(body)}`);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -2213,7 +2213,7 @@ describe('index', function() {
         beforeEach(() => {
             const response = {
                 statusCode: 200,
-                body: JSON.stringify(testPayloadAccessToken)
+                body: testPayloadAccessToken
             };
 
             requestMock.resolves(response);


### PR DESCRIPTION
## Context

Getting error with `_refreshToken()`:
```
api_1    | 210906/113528.737, (1630928128201:e464b22cc7bb:20:kt8k149p:10045) [request,server,error] data: SyntaxError: Unexpected token o in JSON at position 1
api_1    |     at JSON.parse (<anonymous>)
api_1    |     at BitbucketScm._refreshToken (/usr/src/app/node_modules/screwdriver-scm-bitbucket/index.js:1042:27)
api_1    |     at runMicrotasks (<anonymous>)
api_1    |     at processTicksAndRejections (internal/process/task_queues.js:97:5)
api_1    |     at async BitbucketScm._getToken (/usr/src/app/node_modules/screwdriver-scm-bitbucket/index.js:1006:13)
api_1    |     at async BitbucketScm._parseUrl (/usr/src/app/node_modules/screwdriver-scm-bitbucket/index.js:322:23)
api_1    |     at async handler (/usr/src/app/node_modules/screwdriver-api/plugins/pipelines/create.js:32:28)
api_1    |     at async exports.Manager.execute (/usr/src/app/node_modules/@hapi/hapi/lib/toolkit.js:60:28)
api_1    |     at async Object.internals.handler (/usr/src/app/node_modules/@hapi/hapi/lib/handler.js:46:20)
api_1    |     at async exports.execute (/usr/src/app/node_modules/@hapi/hapi/lib/handler.js:31:20)
api_1    |     at async Request._lifecycle (/usr/src/app/node_modules/@hapi/hapi/lib/request.js:372:32)
api_1    |     at async Request._execute (/usr/src/app/node_modules/@hapi/hapi/lib/request.js:280:9)
api_1    | 210906/113528.201, (1630928128201:e464b22cc7bb:20:kt8k149p:10045) [response,api,pipelines] http://localhost:9001: post /v4/pipelines {} 500 (538ms)
```

## Objective

Response for getting token no longer needs to be JSON parsed because the [screwdriver-request repo](https://github.com/screwdriver-cd/request/blob/master/index.js#L21) returns responses in JSON format.

## References

Related to https://github.com/screwdriver-cd/scm-bitbucket/pull/79

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
