### PR TITLE
fix: semantic release

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,12 +5,11 @@
   "main": "index.js",
   "scripts": {
     "pretest": "eslint .",
-    "test": "nyc --report-dir ./artifacts/coverage --reporter=lcov mocha --reporter mocha-multi-reporters --reporter-options configFile=./mocha.config.json --recursive --timeout 4000 --retries 1 --exit --allow-uncaught true --color true",
-    "semantic-release": "semantic-release pre && npm publish && semantic-release post"
+    "test": "nyc --report-dir ./artifacts/coverage --reporter=lcov mocha --reporter mocha-multi-reporters --reporter-options configFile=./mocha.config.json --recursive --timeout 4000 --retries 1 --exit --allow-uncaught true --color true"
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:screwdriver-cd/scm-bitbucket.git"
+    "url": "git+https://github.com/screwdriver-cd/scm-bitbucket.git"
   },
   "homepage": "https://github.com/screwdriver-cd/scm-bitbucket",
   "bugs": "https://github.com/screwdriver-cd/screwdriver/issues",
@@ -30,10 +29,10 @@
     "Tiffany Kyi <tiffanykyi@gmail.com>"
   ],
   "release": {
-    "debug": false,
-    "verifyConditions": {
-      "path": "./node_modules/semantic-release/src/lib/plugin-noop.js"
-    }
+    "branches": [
+      "master"
+    ],
+    "debug": false
   },
   "devDependencies": {
     "chai": "^4.3.4",


### PR DESCRIPTION
## Context

Semantic release is failing since noop package cannot be found.

## Objective

This PR removes old semantic release format.

## References

See https://cd.screwdriver.cd/pipelines/15/builds/777297/steps/publish

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
