### PR TITLE
feat(2676): Support passing in full path for getFile

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
     "debug": false
   },
   "devDependencies": {
-    "chai": "^4.3.4",
-    "eslint": "^7.5.0",
+    "chai": "^4.3.6",
+    "eslint": "^7.32.0",
     "eslint-config-screwdriver": "^5.0.1",
     "mocha": "^8.4.0",
     "mocha-multi-reporters": "^1.5.1",
@@ -46,11 +46,11 @@
     "sinon": "^9.0.0"
   },
   "dependencies": {
-    "@hapi/hoek": "^9.2.0",
-    "circuit-fuses": "^4.0.6",
-    "joi": "^17.2.1",
-    "screwdriver-data-schema": "^21.6.1",
-    "screwdriver-request": "^1.0.0",
-    "screwdriver-scm-base": "^7.2.1"
+    "@hapi/hoek": "^9.2.1",
+    "circuit-fuses": "^4.1.2",
+    "joi": "^17.6.0",
+    "screwdriver-data-schema": "^21.22.2",
+    "screwdriver-request": "^1.0.3",
+    "screwdriver-scm-base": "^7.4.0"
   }
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1004,6 +1004,22 @@ describe('index', function() {
             });
         });
 
+        it('resolves to correct commit sha with fullPath', () => {
+            scmUri = 'hostName:repoId:branchName:src/app/component';
+            params = {
+                scmUri,
+                token,
+                path: 'git@bitbucket.org:screwdriver-cd/reponame.git#main:path/to/file.txt'
+            };
+            expectedOptions.url =
+                'https://api.bitbucket.org/2.0/repositories/screwdriver-cd/reponame/src/main/path/to/file.txt';
+
+            return scm.getFile(params).then(content => {
+                assert.calledWith(requestMock, expectedOptions);
+                assert.deepEqual(content, 'dataValue');
+            });
+        });
+
         it('rejects if status code is not 200', () => {
             fakeResponse = {
                 statusCode: 404,


### PR DESCRIPTION
## Context

In order to support getting provider config dynamically in screwdriver.yaml, we need to be able to pass in the full path to getFile instead of the scmUri, etc.

## Objective

This PR changes getFile method to allow using full path to get repo owner, name, branch, etc info.

## References

https://github.com/screwdriver-cd/screwdriver/issues/2676
Related to https://github.com/screwdriver-cd/scm-github/pull/204

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
