### PR TITLE
fix(2690): Get file as buffer

### DIFF
--- a/index.js
+++ b/index.js
@@ -446,14 +446,13 @@ class BitbucketScm extends Scm {
                 token
             };
 
-            const response = await this.breaker.runCommand(options);
-            const { body } = response;
+            const { body } = await this.breaker.runCommand(options);
 
             return {
-                url: body.links.html.href,
-                name: body.display_name,
-                username: body.uuid,
-                avatar: body.links.avatar.href
+                url: hoek.reach(body, 'links.html.href'),
+                name: hoek.reach(body, 'display_name'),
+                username: hoek.reach(body, 'uuid'),
+                avatar: hoek.reach(body, 'links.avatar.href')
             };
         } catch (err) {
             if (err.statusCode === 404) {
@@ -742,7 +741,7 @@ class BitbucketScm extends Scm {
         try {
             return this.breaker.runCommand(options);
         } catch (err) {
-            if (err.statusCode !== 201 && err.statusCode !== 200) {
+            if (err.statusCode !== 422) {
                 logger.error('Failed to getFile: ', err);
                 throw err;
             }

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "circuit-fuses": "^4.1.2",
     "joi": "^17.6.0",
     "screwdriver-data-schema": "^21.22.2",
+    "screwdriver-logger": "^1.1.0",
     "screwdriver-request": "^1.0.3",
     "screwdriver-scm-base": "^7.4.0"
   }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -522,7 +522,7 @@ describe('index', function() {
                 }
             };
 
-            requestMock.resolves(fakeResponse);
+            requestMock.rejects(fakeResponse);
 
             const expected = {
                 url: '',
@@ -546,32 +546,6 @@ describe('index', function() {
                 .then(decorated => {
                     assert.calledWith(requestMock, expectedFabricatedOptions);
                     assert.deepEqual(decorated, expected);
-                });
-        });
-        it('rejects if status code is not 200', () => {
-            fakeResponse = {
-                statusCode: 404,
-                body: {
-                    error: {
-                        message: 'Resource not found',
-                        detail: 'There is no API hosted at this URL'
-                    }
-                }
-            };
-
-            requestMock.resolves(fakeResponse);
-
-            return scm
-                .decorateAuthor({
-                    username: '{4f1a9b7f-586e-4e80-b9eb-a7589b4a165f}',
-                    token
-                })
-                .then(() => {
-                    assert.fail('Should not get here');
-                })
-                .catch(error => {
-                    assert.calledWith(requestMock, expectedOptions);
-                    assert.match(error.message, 'STATUS CODE 404');
                 });
         });
 
@@ -966,7 +940,8 @@ describe('index', function() {
                 method: 'GET',
                 context: {
                     token: systemToken
-                }
+                },
+                responseType: 'buffer'
             };
             fakeResponse = {
                 statusCode: 200,
@@ -1031,17 +1006,12 @@ describe('index', function() {
                 }
             };
 
-            requestMock.resolves(fakeResponse);
+            requestMock.rejects(fakeResponse);
 
-            return scm
-                .getFile(params)
-                .then(() => {
-                    assert.fail('Should not get here');
-                })
-                .catch(error => {
-                    assert.calledWith(requestMock, expectedOptions);
-                    assert.match(error.message, 'STATUS CODE 404');
-                });
+            return scm.getFile(params).then(content => {
+                assert.calledWith(requestMock, expectedOptions);
+                assert.deepEqual(content, '');
+            });
         });
 
         it('rejects if fails', () => {


### PR DESCRIPTION
## Context

Bitbucket SCM is unable to fetch `screwdriver.yaml` after version >=4.5.0. This is likely related to the change to using screwdriver-request package.

## Objective

This PR switches to taking in file as buffer to avoid screwdriver-request package [throwing error on 200](https://github.com/sindresorhus/got/blob/0703318d3bb6cc1340614612d2ae14b23f651242/source/core/response.ts#L141). Also adds try/catch around decorateAuthor and getFile.
Also adds try/catch to request calls.

_Note: decorateAuthor will return empty for now because of bitbucket's switch from username -> UUID._
Announcement: https://developer.atlassian.com/cloud/bitbucket/bitbucket-api-changes-gdpr/
Related issues: https://stackoverflow.com/questions/53983942/how-to-find-bitbucket-account-uuid, https://community.atlassian.com/t5/Bitbucket-questions/Find-users-in-bitbucket-based-on-nickname/qaq-p/1041707

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/2690

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
