### PR TITLE
fix(2858): Bitbucket - Users without access to a SCM repo can manage the associated pipeline in Screwdriver

### DIFF
--- a/index.js
+++ b/index.js
@@ -644,10 +644,10 @@ class BitbucketScm extends Scm {
      * @param  {String}   config.token      The token used to authenticate to the SCM
      * @return {Promise}                    Resolves to permissions object with admin, push, pull
      */
-    async _getPermissions({ scmUri }) {
+    async _getPermissions(config) {
+        const { scmUri, token } = config;
         const scm = getScmUriParts(scmUri);
         const [owner, uuid] = scm.repoId.split('/');
-        const token = await this._getToken();
 
         try {
             // First, check to see if the repository exists

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -924,139 +924,64 @@ describe('index', function () {
     });
 
     describe('_getPermissions', () => {
-        const repos = [
-            {
-                url: `${API_URL_V2}/repositories/repoIdPrefix/repoIdSuffix`,
-                method: 'GET',
-                context: {
-                    token: systemToken
-                }
-            },
-            {
-                url: `${API_URL_V2}/repositories/repoIdPrefix/repoIdSuffix1`,
-                method: 'GET',
-                context: {
-                    token: systemToken
-                }
-            },
-            {
-                url: `${API_URL_V2}/repositories/repoIdPrefix/repoIdSuffix2`,
-                method: 'GET',
-                context: {
-                    token: systemToken
-                }
-            },
-            {
-                url: `${API_URL_V2}/repositories/repoIdPrefix/repoIdSuffix3`,
-                method: 'GET',
-                context: {
-                    token: systemToken
-                }
-            },
-            {
-                url: `${API_URL_V2}/repositories/repoIdPrefix/fake`,
-                method: 'GET',
-                context: {
-                    token: systemToken
-                }
+        const baseRequestOptions = {
+            method: 'GET',
+            context: {
+                token
             }
+        };
+        const repos = [
+            { ...baseRequestOptions, url: `${API_URL_V2}/repositories/repoIdPrefix/repoIdSuffix` },
+            { ...baseRequestOptions, url: `${API_URL_V2}/repositories/repoIdPrefix/repoIdSuffix1` },
+            { ...baseRequestOptions, url: `${API_URL_V2}/repositories/repoIdPrefix/repoIdSuffix2` },
+            { ...baseRequestOptions, url: `${API_URL_V2}/repositories/repoIdPrefix/repoIdSuffix3` },
+            { ...baseRequestOptions, url: `${API_URL_V2}/repositories/repoIdPrefix/fake` }
         ];
 
         const pull = {
-            url: `${API_URL_V2}/repositories/repoIdPrefix?q=uuid%3D%22repoIdSuffix%22`,
-            method: 'GET',
-            context: {
-                token: systemToken
-            }
+            ...baseRequestOptions,
+            url: `${API_URL_V2}/repositories/repoIdPrefix?q=uuid%3D%22repoIdSuffix%22`
         };
         const pulls = [
-            {
-                url: `${API_URL_V2}/repositories/repoIdPrefix?q=uuid%3D%22repoIdSuffix%22`,
-                method: 'GET',
-                context: {
-                    token: systemToken
-                }
-            },
-            {
-                url: `${API_URL_V2}/repositories/repoIdPrefix?q=uuid%3D%22repoIdSuffix1%22`,
-                method: 'GET',
-                context: {
-                    token: systemToken
-                }
-            },
-            {
-                url: `${API_URL_V2}/repositories/repoIdPrefix?q=uuid%3D%22repoIdSuffix2%22`,
-                method: 'GET',
-                context: {
-                    token: systemToken
-                }
-            },
-            {
-                url: `${API_URL_V2}/repositories/repoIdPrefix?q=uuid%3D%22repoIdSuffix3%22`,
-                method: 'GET',
-                context: {
-                    token: systemToken
-                }
-            }
+            { ...baseRequestOptions, url: `${API_URL_V2}/repositories/repoIdPrefix?q=uuid%3D%22repoIdSuffix%22` },
+            { ...baseRequestOptions, url: `${API_URL_V2}/repositories/repoIdPrefix?q=uuid%3D%22repoIdSuffix1%22` },
+            { ...baseRequestOptions, url: `${API_URL_V2}/repositories/repoIdPrefix?q=uuid%3D%22repoIdSuffix2%22` },
+            { ...baseRequestOptions, url: `${API_URL_V2}/repositories/repoIdPrefix?q=uuid%3D%22repoIdSuffix3%22` }
         ];
         const pushes = [
             {
-                url: `${API_URL_V2}/repositories/repoIdPrefix?q=uuid%3D%22repoIdSuffix%22&role=contributor`,
-                method: 'GET',
-                context: {
-                    token: systemToken
-                }
+                ...baseRequestOptions,
+                url: `${API_URL_V2}/repositories/repoIdPrefix?q=uuid%3D%22repoIdSuffix%22&role=contributor`
             },
             {
-                url: `${API_URL_V2}/repositories/repoIdPrefix?q=uuid%3D%22repoIdSuffix1%22&role=contributor`,
-                method: 'GET',
-                context: {
-                    token: systemToken
-                }
+                ...baseRequestOptions,
+                url: `${API_URL_V2}/repositories/repoIdPrefix?q=uuid%3D%22repoIdSuffix1%22&role=contributor`
             },
             {
-                url: `${API_URL_V2}/repositories/repoIdPrefix?q=uuid%3D%22repoIdSuffix2%22&role=contributor`,
-                method: 'GET',
-                context: {
-                    token: systemToken
-                }
+                ...baseRequestOptions,
+                url: `${API_URL_V2}/repositories/repoIdPrefix?q=uuid%3D%22repoIdSuffix2%22&role=contributor`
             },
             {
-                url: `${API_URL_V2}/repositories/repoIdPrefix?q=uuid%3D%22repoIdSuffix3%22&role=contributor`,
-                method: 'GET',
-                context: {
-                    token: systemToken
-                }
+                ...baseRequestOptions,
+                url: `${API_URL_V2}/repositories/repoIdPrefix?q=uuid%3D%22repoIdSuffix3%22&role=contributor`
             }
         ];
         const admins = [
             {
-                url: `${API_URL_V2}/repositories/repoIdPrefix?q=uuid%3D%22repoIdSuffix%22&role=admin`,
-                method: 'GET',
-                context: {
-                    token: systemToken
-                }
+                ...baseRequestOptions,
+                url: `${API_URL_V2}/repositories/repoIdPrefix?q=uuid%3D%22repoIdSuffix%22&role=admin`
             },
             {
-                url: `${API_URL_V2}/repositories/repoIdPrefix?q=uuid%3D%22repoIdSuffix1%22&role=admin`,
-                method: 'GET',
-                context: {
-                    token: systemToken
-                }
+                ...baseRequestOptions,
+                url: `${API_URL_V2}/repositories/repoIdPrefix?q=uuid%3D%22repoIdSuffix1%22&role=admin`
             },
             {
-                url: `${API_URL_V2}/repositories/repoIdPrefix?q=uuid%3D%22repoIdSuffix2%22&role=admin`,
-                method: 'GET',
-                context: {
-                    token: systemToken
-                }
+                ...baseRequestOptions,
+                url: `${API_URL_V2}/repositories/repoIdPrefix?q=uuid%3D%22repoIdSuffix2%22&role=admin`
             },
             {
-                url: `${API_URL_V2}/repositories/repoIdPrefix?q=uuid%3D%22repoIdSuffix3%22&role=admin`,
-                method: 'GET',
-                context: {
-                    token: systemToken
-                }
+                ...baseRequestOptions,
+                url: `${API_URL_V2}/repositories/repoIdPrefix?q=uuid%3D%22repoIdSuffix3%22&role=admin`
             }
         ];
 


### PR DESCRIPTION
## Context

Users in Bitbucket can perform below restricted operations on a pipeline associated with repository for which they do not have access (admin/write)

Add/Update secrets
Add/Update tokens
Start build
Sync Pipeline/PRs
.... and more

## Objective

Use token associated with the logged in user to fetch the permissions from SCM for the pipeline repository.
This would forbidden above mentioned operations in the Screwdriver to the user without write/admin access the the pipeline SCM repository.

## References

https://github.com/screwdriver-cd/screwdriver/issues/2858

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
