### PR TITLE
feat(2892): get BitBucket user ID

### DIFF
--- a/index.js
+++ b/index.js
@@ -439,6 +439,7 @@ class BitbucketScm extends Scm {
             const { body } = await this.breaker.runCommand(options);
 
             return {
+                id: hoek.reach(body, 'uuid'),
                 url: hoek.reach(body, 'links.html.href'),
                 name: hoek.reach(body, 'display_name'),
                 username: hoek.reach(body, 'uuid'),

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -471,6 +471,7 @@ describe('index', function () {
 
         it('resolves to correct decorated author', () => {
             const expected = {
+                id: '{4f1a9b7f-586e-4e80-b9eb-a7589b4a165f}',
                 url: 'https://bitbucket.org/%7B4f1a9b7f-586e-4e80-b9eb-a7589b4a165f%7D/',
                 name: 'Batman',
                 username: '{4f1a9b7f-586e-4e80-b9eb-a7589b4a165f}',
@@ -682,6 +683,7 @@ describe('index', function () {
                 url: selfLink,
                 message: 'testing',
                 author: {
+                    id: '{uuid}',
                     url: 'https://bitbucket.org/%7Buuid%7D/',
                     name: 'displayName',
                     username: '{uuid}',


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

The following PR needs to get a SCM user id.
https://github.com/screwdriver-cd/screwdriver/pull/2890

This PR will include a BitBucket id in the return value of `decorateAuthor`.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

This PR will add a BitBucket id in the return value of `decorateAuthor`.

I cannot actually test this by BitBucket API, so try this please.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

Issue

- https://github.com/screwdriver-cd/screwdriver/issues/2892

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
