### PR TITLE
fix(3225): organize the return values of _parseHook [3]

### DIFF
--- a/test/data/issue.create.json
+++ b/test/data/issue.create.json
@@ -1,0 +1,85 @@
+{
+    "issue": {
+        "id": 1,
+        "component": "component",
+        "title": "Issue title",
+        "content": {
+            "raw": "Issue description",
+            "html": "<p>Issue description</p>",
+            "markup": "markdown"
+        },
+        "priority": "trivial|minor|major|critical|blocker",
+        "state": "submitted|new|open|on hold|resolved|duplicate|invalid|wontfix|closed",
+        "type": "bug|enhancement|proposal|task",
+        "milestone": {
+            "name": "milestone 1"
+        },
+        "version": {
+            "name": "version 1"
+        },
+        "created_on": "2015-04-06T15:23:38.179678+00:00",
+        "updated_on": "2015-04-06T15:23:38.179678+00:00",
+        "links": {
+            "self": {
+                "href": "https://api.bitbucket.org/api/2.0/issues/issue_id"
+            },
+            "html": {
+                "href": "https://api.bitbucket.org/issue_id"
+            }
+        }
+    },
+    "repository": {
+        "scm": "git",
+        "website": "",
+        "name": "test",
+        "links": {
+            "self": {
+                "href": "https://api.bitbucket.org/2.0/repositories/batman/test"
+            },
+            "html": {
+                "href": "https://bitbucket.org/batman/test"
+            },
+            "avatar": {
+                "href": "https://bitbucket.org/batman/test/avatar/32/"
+            }
+        },
+        "full_name": "batman/test",
+        "owner": {
+            "username": "batman",
+            "display_name": "Batman",
+            "type": "user",
+            "uuid": "{2dca4f54-ab3f-400c-a777-c059e1ac0394}",
+            "links": {
+                "self": {
+                    "href": "https://api.bitbucket.org/2.0/users/batman"
+                },
+                "html": {
+                    "href": "https://bitbucket.org/batman/"
+                },
+                "avatar": {
+                    "href": "https://bitbucket.org/account/batman/avatar/32/"
+                }
+            }
+        },
+        "type": "repository",
+        "is_private": true,
+        "uuid": "{de7d7695-1196-46a1-b87d-371b7b2945ab}"
+    },
+    "actor": {
+        "username": "robin",
+        "display_name": "Robin",
+        "type": "user",
+        "uuid": "{2dca4f54-ab3f-400c-a777-c059e1ac0394}",
+        "links": {
+            "self": {
+                "href": "https://api.bitbucket.org/2.0/users/robin"
+            },
+            "html": {
+                "href": "https://bitbucket.org/robin/"
+            },
+            "avatar": {
+                "href": "https://bitbucket.org/account/robin/avatar/32/"
+            }
+        }
+    }
+}

--- a/test/data/pr.commentCreate.json
+++ b/test/data/pr.commentCreate.json
@@ -1,0 +1,184 @@
+{
+    "pullrequest": {
+        "type": "pullrequest",
+        "description": "* stuff\r\n\r\n* testpayload\r\n\r\n* testing",
+        "links": {
+            "self": {
+                "href": "https://api.bitbucket.org/2.0/repositories/batman/test/pullrequests/3"
+            },
+            "html": {
+                "href": "https://bitbucket.org/batman/test/pull-requests/3"
+            }
+        },
+        "title": "Mynewbranch",
+        "close_source_branch": false,
+        "reviewers": [],
+        "destination": {
+            "commit": {
+                "hash": "4bcb8de69a58",
+                "links": {
+                    "self": {
+                        "href": "https://api.bitbucket.org/2.0/repositories/batman/test/commit/4bcb8de69a58"
+                    }
+                }
+            },
+            "branch": {
+                "name": "master"
+            },
+            "repository": {
+                "links": {
+                    "self": {
+                        "href": "https://api.bitbucket.org/2.0/repositories/batman/test"
+                    },
+                    "html": {
+                        "href": "https://bitbucket.org/batman/test"
+                    },
+                    "avatar": {
+                        "href": "https://bitbucket.org/batman/test/avatar/32/"
+                    }
+                },
+                "type": "repository",
+                "uuid": "{de7d7695-1196-46a1-b87d-371b7b2945ab}",
+                "full_name": "batman/test",
+                "name": "test"
+            }
+        },
+        "reason": "",
+        "closed_by": null,
+        "source": {
+            "commit": {
+                "hash": "40171b678527",
+                "links": {
+                    "self": {
+                        "href": "https://api.bitbucket.org/2.0/repositories/batman/test/commit/40171b678527"
+                    }
+                }
+            },
+            "branch": {
+                "name": "mynewbranch"
+            },
+            "repository": {
+                "links": {
+                    "self": {
+                        "href": "https://api.bitbucket.org/2.0/repositories/batman/test"
+                    },
+                    "html": {
+                        "href": "https://bitbucket.org/batman/test"
+                    },
+                    "avatar": {
+                        "href": "https://bitbucket.org/batman/test/avatar/32/"
+                    }
+                },
+                "type": "repository",
+                "uuid": "{de7d7695-1196-46a1-b87d-371b7b2945ab}",
+                "full_name": "batman/test",
+                "name": "test"
+            }
+        },
+        "comment_count": 0,
+        "state": "OPEN",
+        "author": {
+            "username": "batman",
+            "display_name": "Batman",
+            "type": "user",
+            "uuid": "{2dca4f54-ab3f-400c-a777-c059e1ac0394}",
+            "links": {
+                "self": {
+                    "href": "https://api.bitbucket.org/2.0/users/batman"
+                },
+                "html": {
+                    "href": "https://bitbucket.org/batman/"
+                },
+                "avatar": {
+                    "href": "https://bitbucket.org/account/batman/avatar/32/"
+                }
+            }
+        },
+        "created_on": "2016-10-11T00:05:17.748641+00:00",
+        "participants": [],
+        "updated_on": "2016-10-11T00:05:17.763900+00:00",
+        "merge_commit": null,
+        "id": 3,
+        "task_count": 0
+    },
+    "actor": {
+        "username": "robin",
+        "display_name": "Robin",
+        "type": "user",
+        "uuid": "{2dca4f54-ab3f-400c-a777-c059e1ac0394}",
+        "links": {
+            "self": {
+                "href": "https://api.bitbucket.org/2.0/users/robin"
+            },
+            "html": {
+                "href": "https://bitbucket.org/robin/"
+            },
+            "avatar": {
+                "href": "https://bitbucket.org/account/robin/avatar/32/"
+            }
+        }
+    },
+    "repository": {
+        "scm": "git",
+        "website": "",
+        "uuid": "{de7d7695-1196-46a1-b87d-371b7b2945ab}",
+        "links": {
+            "self": {
+                "href": "https://api.bitbucket.org/2.0/repositories/batman/test"
+            },
+            "html": {
+                "href": "https://bitbucket.org/batman/test"
+            },
+            "avatar": {
+                "href": "https://bitbucket.org/batman/test/avatar/32/"
+            }
+        },
+        "full_name": "batman/test",
+        "owner": {
+            "username": "batman",
+            "display_name": "Batman",
+            "type": "user",
+            "uuid": "{2dca4f54-ab3f-400c-a777-c059e1ac0394}",
+            "links": {
+                "self": {
+                    "href": "https://api.bitbucket.org/2.0/users/batman"
+                },
+                "html": {
+                    "href": "https://bitbucket.org/batman/"
+                },
+                "avatar": {
+                    "href": "https://bitbucket.org/account/batman/avatar/32/"
+                }
+            }
+        },
+        "type": "repository",
+        "is_private": true,
+        "name": "test"
+    },
+    "comment": {
+        "id": 17,
+        "parent": {
+            "id": 16
+        },
+        "content": {
+            "raw": "Comment text",
+            "html": "<p>Comment text</p>",
+            "markup": "markdown"
+        },
+        "inline": {
+            "path": "path/to/file",
+            "from": null,
+            "to": 10
+        },
+        "created_on": "2015-04-06T16:52:29.982346+00:00",
+        "updated_on": "2015-04-06T16:52:29.983730+00:00",
+        "links": {
+            "self": {
+                "href": "https://api.bitbucket.org/api/2.0/comments/comment_id"
+            },
+            "html": {
+                "href": "https://api.bitbucket.org/comment_id"
+            }
+        }
+    }
+}

--- a/test/data/repo.fork.json
+++ b/test/data/repo.fork.json
@@ -1,0 +1,93 @@
+{
+    "fork": {
+        "scm": "git",
+        "website": "",
+        "name": "test",
+        "links": {
+            "self": {
+                "href": "https://api.bitbucket.org/2.0/repositories/batman/test2"
+            },
+            "html": {
+                "href": "https://bitbucket.org/batman/test2"
+            },
+            "avatar": {
+                "href": "https://bitbucket.org/batman/test2/avatar/32/"
+            }
+        },
+        "full_name": "batman/test2",
+        "owner": {
+            "username": "batman",
+            "display_name": "Batman",
+            "type": "user",
+            "uuid": "{2dca4f54-ab3f-400c-a777-c059e1ac0394}",
+            "links": {
+                "self": {
+                    "href": "https://api.bitbucket.org/2.0/users/batman"
+                },
+                "html": {
+                    "href": "https://bitbucket.org/batman/"
+                },
+                "avatar": {
+                    "href": "https://bitbucket.org/account/batman/avatar/32/"
+                }
+            }
+        },
+        "type": "repository",
+        "is_private": true,
+        "uuid": "{de7d7695-1196-46a1-b87d-371b7b2945ab}"
+    },
+    "repository": {
+        "scm": "git",
+        "website": "",
+        "name": "test",
+        "links": {
+            "self": {
+                "href": "https://api.bitbucket.org/2.0/repositories/batman/test"
+            },
+            "html": {
+                "href": "https://bitbucket.org/batman/test"
+            },
+            "avatar": {
+                "href": "https://bitbucket.org/batman/test/avatar/32/"
+            }
+        },
+        "full_name": "batman/test",
+        "owner": {
+            "username": "batman",
+            "display_name": "Batman",
+            "type": "user",
+            "uuid": "{2dca4f54-ab3f-400c-a777-c059e1ac0394}",
+            "links": {
+                "self": {
+                    "href": "https://api.bitbucket.org/2.0/users/batman"
+                },
+                "html": {
+                    "href": "https://bitbucket.org/batman/"
+                },
+                "avatar": {
+                    "href": "https://bitbucket.org/account/batman/avatar/32/"
+                }
+            }
+        },
+        "type": "repository",
+        "is_private": true,
+        "uuid": "{de7d7695-1196-46a1-b87d-371b7b2945ab}"
+    },
+    "actor": {
+        "username": "robin",
+        "display_name": "Robin",
+        "type": "user",
+        "uuid": "{2dca4f54-ab3f-400c-a777-c059e1ac0394}",
+        "links": {
+            "self": {
+                "href": "https://api.bitbucket.org/2.0/users/robin"
+            },
+            "html": {
+                "href": "https://bitbucket.org/robin/"
+            },
+            "avatar": {
+                "href": "https://bitbucket.org/account/robin/avatar/32/"
+            }
+        }
+    }
+}

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1888,7 +1888,7 @@ describe('index', function () {
             });
         });
 
-        it('returns a false when _parseHook() returns null.', () => {
+        it('returns a true when _parseHook() returns null.', () => {
             headers['x-event-key'] = 'issue:created';
 
             return scm.canHandleWebhook(headers, testPayloadPush).then(result => {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -14,7 +14,10 @@ const testRootDirCommands = require('./data/rootDirCommands.json');
 const testPayloadOpen = require('./data/pr.opened.json');
 const testPayloadSync = require('./data/pr.sync.json');
 const testPayloadClose = require('./data/pr.closed.json');
+const testPayloadPrCommentCreate = require('./data/pr.commentCreate.json');
+const testPayloadFork = require('./data/repo.fork.json');
 const testPayloadPush = require('./data/repo.push.json');
+const testPayloadIssueCreate = require('./data/issue.create.json');
 const testPayloadAccessToken = require('./data/access.token.json');
 const token = 'myAccessToken';
 const systemToken = 'myAccessToken2';
@@ -419,7 +422,7 @@ describe('index', function () {
                 'x-event-key': 'repo:fork'
             };
 
-            return scm.parseHook(repoFork, {}).then(result => assert.deepEqual(result, null));
+            return scm.parseHook(repoFork, testPayloadFork).then(result => assert.deepEqual(result, null));
         });
 
         it('resolves null if events are not supported: prComment', () => {
@@ -427,7 +430,7 @@ describe('index', function () {
                 'x-event-key': 'pullrequest:comment_created'
             };
 
-            return scm.parseHook(prComment, {}).then(result => assert.deepEqual(result, null));
+            return scm.parseHook(prComment, testPayloadPrCommentCreate).then(result => assert.deepEqual(result, null));
         });
 
         it('resolves null if events are not supported: issueCreated', () => {
@@ -435,7 +438,7 @@ describe('index', function () {
                 'x-event-key': 'issue:created'
             };
 
-            return scm.parseHook(issueCreated, {}).then(result => assert.deepEqual(result, null));
+            return scm.parseHook(issueCreated, testPayloadIssueCreate).then(result => assert.deepEqual(result, null));
         });
     });
 
@@ -1889,13 +1892,13 @@ describe('index', function () {
             headers['x-event-key'] = 'issue:created';
 
             return scm.canHandleWebhook(headers, testPayloadPush).then(result => {
-                assert.isFalse(result);
+                assert.isTrue(result);
             });
         });
 
         it('returns false when an error is thrown', () => {
             // eslint-disable-next-line no-underscore-dangle
-            scm._parseHook = () => Promise.resolve({});
+            scm._parseHook = () => Promise.reject(new Error('Test error'));
 
             return scm.canHandleWebhook(headers, testPayloadPush).then(result => {
                 assert.strictEqual(result, false);


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

Currently, the `_parseHook` method  returns Object or null or throw Error.
However, their return values are not properly conditioned.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Organize the return values by the following:

- return Object (parsed result): the `scm` is correct and Screwdriver do actions with the webhook (e.g. `push` event)
- return null: the `scm` is correct and Screwdriver do nothing (e.g. `delete` event)
- throw Error: the `scm` is not correct

Then we can handle whether the webhook is correct or not at [here](https://github.com/screwdriver-cd/screwdriver/blob/ef31fca55eaff2548f7486795de41e84f87a675d/plugins/webhooks/index.js#L68-L73).

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

Issue
- https://github.com/screwdriver-cd/screwdriver/issues/3225

PR
- https://github.com/screwdriver-cd/scm-router/pull/37

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
