### PR TITLE
feat: add prMerged flag to webhook result 

### DIFF
--- a/index.js
+++ b/index.js
@@ -419,6 +419,9 @@ class BitbucketScm extends Scm {
                 parsed.sha = hoek.reach(payload, 'pullrequest.source.commit.hash');
                 parsed.prNum = hoek.reach(payload, 'pullrequest.id');
                 parsed.prRef = hoek.reach(payload, 'pullrequest.source.branch.name');
+                
+                const state = hoek.reach(payload, 'pullrequest.state')
+                parsed.prMerged = state === 'MERGED';
 
                 return parsed;
             }

--- a/index.js
+++ b/index.js
@@ -374,7 +374,7 @@ class BitbucketScm extends Scm {
         parsed.scmContext = scmContexts[0];
 
         if (hoek.reach(payload, 'repository.links.html.href') === undefined) {
-            throwError(`Invalid webhook payload`, 400);
+            throwError('Invalid webhook payload', 400);
         }
 
         const link = Url.parse(hoek.reach(payload, 'repository.links.html.href'));
@@ -419,8 +419,9 @@ class BitbucketScm extends Scm {
                 parsed.sha = hoek.reach(payload, 'pullrequest.source.commit.hash');
                 parsed.prNum = hoek.reach(payload, 'pullrequest.id');
                 parsed.prRef = hoek.reach(payload, 'pullrequest.source.branch.name');
-                
-                const state = hoek.reach(payload, 'pullrequest.state')
+
+                const state = hoek.reach(payload, 'pullrequest.state');
+
                 parsed.prMerged = state === 'MERGED';
 
                 return parsed;
@@ -811,8 +812,8 @@ class BitbucketScm extends Scm {
         // Set recursive option
         command.push(
             'if [ ! -z $GIT_RECURSIVE_CLONE ] && [ $GIT_RECURSIVE_CLONE = false ]; ' +
-                `then export GIT_RECURSIVE_OPTION=""; ` +
-                `else export GIT_RECURSIVE_OPTION="--recursive"; fi`
+                'then export GIT_RECURSIVE_OPTION=""; ' +
+                'else export GIT_RECURSIVE_OPTION="--recursive"; fi'
         );
 
         // Checkout config pipeline if this is a child pipeline

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -324,7 +324,8 @@ describe('index', function () {
                 prNum: 3,
                 prRef: 'mynewbranch',
                 hookId: '1e8d4e8e-5fcf-4624-b091-b10bd6ecaf5e',
-                scmContext: 'bitbucket:bitbucket.org'
+                scmContext: 'bitbucket:bitbucket.org',
+                prMerged: false
             };
             const headers = {
                 'x-event-key': 'pullrequest:created',
@@ -345,7 +346,8 @@ describe('index', function () {
                 prNum: 7,
                 prRef: 'prbranch',
                 hookId: '1e8d4e8e-5fcf-4624-b091-b10bd6ecaf5e',
-                scmContext: 'bitbucket:bitbucket.org'
+                scmContext: 'bitbucket:bitbucket.org',
+                prMerged: false
             };
             const headers = {
                 'x-event-key': 'pullrequest:updated',
@@ -366,7 +368,8 @@ describe('index', function () {
                 prNum: 3,
                 prRef: 'mynewbranch',
                 hookId: '1e8d4e8e-5fcf-4624-b091-b10bd6ecaf5e',
-                scmContext: 'bitbucket:bitbucket.org'
+                scmContext: 'bitbucket:bitbucket.org',
+                prMerged: true
             };
             const headers = {
                 'x-event-key': 'pullrequest:fullfilled',
@@ -387,7 +390,8 @@ describe('index', function () {
                 prNum: 3,
                 prRef: 'mynewbranch',
                 hookId: '1e8d4e8e-5fcf-4624-b091-b10bd6ecaf5e',
-                scmContext: 'bitbucket:bitbucket.org'
+                scmContext: 'bitbucket:bitbucket.org',
+                prMerged: true
             };
             const headers = {
                 'x-event-key': 'pullrequest:rejected',


### PR DESCRIPTION
## Context

SD configuration currently does not support pull_request closed trigger, to enable this feature we need to additional parsed information from webhook

## Objective

This PR adds `prMerged` flag to parsed webhook response

## References

https://github.com/screwdriver-cd/data-schema/pull/597

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
