### PR TITLE
fix(3384): Failure to get user info from scm should not throw error

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,6 @@
     "screwdriver-data-schema": "^25.0.0",
     "screwdriver-logger": "^3.0.0",
     "screwdriver-request": "^3.0.0",
-    "screwdriver-scm-base": "^10.0.0"
+    "screwdriver-scm-base": "^10.0.1"
   }
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -533,22 +533,28 @@ describe('index', function () {
                 });
         });
 
-        it('rejects if fails', () => {
+        it('resolves with author with default values for the optional fields when there is a failure', () => {
             const err = new Error('Bitbucket API error');
+            const username = '{4f1a9b7f-586e-4e80-b9eb-a7589b4a165f}';
 
             requestMock.rejects(err);
 
             return scm
                 .decorateAuthor({
-                    username: '{4f1a9b7f-586e-4e80-b9eb-a7589b4a165f}',
+                    username,
                     token
                 })
-                .then(() => {
-                    assert.fail('Should not get here');
-                })
-                .catch(error => {
-                    assert.calledWith(requestMock, expectedOptions);
-                    assert.equal(error, err);
+                .then(author => {
+                    assert.deepEqual(
+                        {
+                            id: '',
+                            avatar: 'https://cd.screwdriver.cd/assets/unknown_user.png',
+                            name: username,
+                            username,
+                            url: 'https://cd.screwdriver.cd/'
+                        },
+                        author
+                    );
                 });
         });
     });


### PR DESCRIPTION
## Context

Changes made in the https://github.com/screwdriver-cd/scm-base/pull/101 has resulted in few test failures

## Objective

Adapt the tests to align with the latest changes

## References

https://github.com/screwdriver-cd/screwdriver/issues/3384

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
